### PR TITLE
Remove deprecated JVM option UseConcMarkSweepGC

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -19,4 +19,4 @@
   {:extra-paths ["classes"]
    :jvm-opts ["-client" "-Xmx2g" "-Xverify:none"
               "-XX:+TieredCompilation" "-XX:TieredStopAtLevel=1"
-              "-XX:+UseConcMarkSweepGC" "-XX:+CMSClassUnloadingEnabled"]}}}
+              "-XX:+CMSClassUnloadingEnabled"]}}}


### PR DESCRIPTION
Hi there, I came across your project and took it for a spin 🙌

This patch fixes the following warning (printed after exiting neovim):

    OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.

We shouldn't need to specify a particular garbage collector implementation; let the JVM choose.

(You probably don't need `CMSClassUnloadingEnabled` either – it's ignored by the newer garbage collectors – but it doesn't do any harm.)