### PR TITLE
Stop JVM gracefully

### DIFF
--- a/src/conjure/main.clj
+++ b/src/conjure/main.clj
@@ -11,9 +11,18 @@
             [conjure.ui :as ui]
             [conjure.action :as action]))
 
+(defn- clean-up-and-exit
+  "Performs any necessary clean up and calls `(System/exit status)`."
+  []
+  (shutdown-agents)
+  (flush)
+  (binding [*out* *err*] (flush))
+  (System/exit 0))
+
 (defn -main
   "Start up any background services and then wait forever."
   []
+  (.addShutdownHook (Runtime/getRuntime) (Thread. #(clean-up-and-exit)))
   (dev/init)
   (rpc/init))
 


### PR DESCRIPTION
Every time I quit neovim, I get a message on the terminal: `Conjure exited, restarting`, and the process never terminates, I need to kill it with `CTRL-C`, but it leaves a zombie java process on my system.

Debugging it, I found that conjure always exits with code 143. I think it means that the application was terminated due to a SIGTERM command.

I'm using openjdk version "1.8.0_202".

I took the `clean-up-and-exit` function from [nrepl](https://github.com/nrepl/nrepl):
https://github.com/nrepl/nrepl/blob/2b432c859c5a98b6e8c97338315bfaab2961641b/src/clojure/nrepl/cmdline.clj#L17-L23