### PR TITLE
Make Conjure log window size and direction configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ You can disable these and define your own with `let g:conjure_default_mappings =
 
 If you get something wrong it'll explain using [Expound][] in the log buffer. Essentially you must provide at least a `:tag` and `:port`.
 
+### Options
+
+ * `g:conjure_log_direction` - How to split the log window. `"vertical"` or `"horizontal"`. Defaults to `"vertical"`.
+ * `g:conjure_log_size_small` - Percentage size of the window used by Conjure log. A number between 1 and 100, defaults to 25.
+ * `g:conjure_log_size_large` - Percentage size of the window used by Conjure log **when open with `ConjureOpenLog`**. A number between 1 and 100, defaults to 50.
+
 ## Completion
 
 Completion is provided through the wonderful [Compliment][] and is injected for you without conflicting with existing versions. `<c-x><c-o>` omnicompletion should work as soon as you're connected.

--- a/autoload/conjure.vim
+++ b/autoload/conjure.vim
@@ -8,6 +8,10 @@ else
   let s:job_opts = "-A:fast"
 endif
 
+let g:conjure_log_direction = get(g:, 'conjure_log_direction', "vertical")
+let g:conjure_log_size_small = get(g:, 'conjure_log_size_small', 25)
+let g:conjure_log_size_large = get(g:, 'conjure_log_size_large', 50)
+
 " Create commands for RPC calls handled by main.clj.
 command! -nargs=1 ConjureAdd call rpcnotify(s:jobid, "add", <q-args>)
 command! -nargs=1 ConjureRemove call rpcnotify(s:jobid, "remove", <q-args>)

--- a/src/conjure/main.clj
+++ b/src/conjure/main.clj
@@ -89,7 +89,7 @@
 (defmethod rpc/handle-notify :open-log [_]
   (ui/upsert-log {:focus? true
                   :resize? true
-                  :width :large}))
+                  :size :large}))
 
 (defmethod rpc/handle-notify :close-log [_]
   (ui/close-log))

--- a/src/conjure/nvim/api.clj
+++ b/src/conjure/nvim/api.clj
@@ -64,8 +64,22 @@
   {:method :nvim-buf-set-var
    :params [buf (util/kw->snake name) value]})
 
+(defn get-var
+  [name]
+  {:method :nvim-get-var
+   :params [(util/kw->snake name)]})
+
 (defn set-var [name value]
   {:method :nvim-set-var
+   :params [(util/kw->snake name) value]})
+
+(defn get-option
+  [name]
+  {:method :nvim-get-option
+   :params [(util/kw->snake name)]})
+
+(defn set-option [name value]
+  {:method :nvim-set-option
    :params [(util/kw->snake name) value]})
 
 (defn execute-lua [code & args]

--- a/src/conjure/ui.clj
+++ b/src/conjure/ui.clj
@@ -5,7 +5,6 @@
             [conjure.code :as code]
             [conjure.result :as result]))
 
-(def ^:private log-window-widths {:small 40 :large 80})
 (def ^:private max-log-buffer-length 2000)
 (defonce ^:private log-buffer-name "/tmp/conjure.cljc")
 (def ^:private welcome-msg "; conjure/out | Welcome to Conjure!")
@@ -13,11 +12,11 @@
 (defn upsert-log
   "Get, create, or update the log window and buffer."
   ([] (upsert-log {}))
-  ([{:keys [focus? resize? width] :or {focus? false, resize? false, width :small}}]
+  ([{:keys [focus? resize? size] :or {focus? false, resize? false, size :small}}]
    (-> (nvim/call-lua-function
          :upsert-log
          log-buffer-name
-         (get log-window-widths width)
+         (util/kw->snake size)
          focus?
          resize?)
        (util/snake->kw-map))))


### PR DESCRIPTION
Related to #7, I wanted to see how looks like if Conjure's window log opens in an horizontal split, and wrote this code.

It adds 3 new variables, `g:conjure_log_direction`, `g:conjure_log_size_small` and `g:conjure_log_size_large` to define the direction and size of the Conjure log window.

Also modifies the size meaning. Before the size was the number of columns to use, now it is the percentage of the window to use. 
To me, makes more sense to make it a percentage, since sometimes I work on a small monitor (laptop) and other times on a bigger one.