### PR TITLE
Quick doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can find out more about socket prepls in my blog post, [Clojure socket prepl
  * Running tests in the current namespace or the `-test` equivalent.
  * Friendly error output by default with optional expansion.
  * Go to definition.
- * `(doc ...)` lookup on `K` or via `CursorHold` for your current form.
+ * Documentation lookup on a key press and when your cursor is idle.
 
 ### Upcoming
 
@@ -44,7 +44,7 @@ The `'for'` and `'on'` keys are optional but you might prefer Conjure to only st
 You can disable these and define your own with `let g:conjure_default_mappings = 0`.
 
  * `InsertEnter` in a Clojure buffer (that is _not_ the log) closes the log.
- * `CursorHold` in a Clojure buffer looks up the docs for the head of the form under your cursor and echos it. If this is annoying you, turn it off with `let g:conjure_quick_doc = 0`
+ * `CursorHold` in a Clojure buffer looks up the docs for the head of the form under your cursor and displays it with virtual text.
  * `<localleader>ee` - `ConjureEvalCurrentForm`
  * `<localleader>er` - `ConjureEvalRootForm`
  * `<localleader>ee` - `ConjureEvalSelection` (visual mode)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Here's an example with [vim-plug][], my plugin manager of choice.
 Plug 'Olical/conjure', { 'tag': 'v0.14.2', 'do': 'bin/compile', 'for': 'clojure', 'on': 'ConjureAdd'  }
 ```
 
-You should rely on a tag so that breaking changes don't end up disrupting your workflow, please don't depend on `master`. Make sure you watch the repository for releases using the menu in the top right, that way you can upgrade when it's convenient for you.
+You should rely on a tag so that breaking changes don't end up disrupting your workflow, please don't depend on `master` (and especially not `develop`!). Make sure you watch the repository for releases using the menu in the top right, that way you can upgrade when it's convenient for you.
 
 The `'for'` and `'on'` keys are optional but you might prefer Conjure to only start up once you've entered a Clojure file.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can find out more about socket prepls in my blog post, [Clojure socket prepl
  * Running tests in the current namespace or the `-test` equivalent.
  * Friendly error output by default with optional expansion.
  * Go to definition.
- * `(doc ...)` lookup.
+ * `(doc ...)` lookup on `K` or via `CursorHold` for your current form.
 
 ### Upcoming
 
@@ -44,6 +44,7 @@ The `'for'` and `'on'` keys are optional but you might prefer Conjure to only st
 You can disable these and define your own with `let g:conjure_default_mappings = 0`.
 
  * `InsertEnter` in a Clojure buffer (that is _not_ the log) closes the log.
+ * `CursorHold` in a Clojure buffer looks up the docs for the head of the form under your cursor and echos it. If this is annoying you, turn it off with `let g:conjure_quick_doc = 0`
  * `<localleader>ee` - `ConjureEvalCurrentForm`
  * `<localleader>er` - `ConjureEvalRootForm`
  * `<localleader>ee` - `ConjureEvalSelection` (visual mode)

--- a/deps.edn
+++ b/deps.edn
@@ -4,6 +4,7 @@
  {org.clojure/clojure {:mvn/version "1.10.0"}
   org.clojure/core.async {:mvn/version "0.4.490"}
   org.clojure/spec.alpha {:mvn/version "0.2.176"}
+  org.clojure/tools.reader {:mvn/version "1.3.2"}
   com.taoensso/timbre {:mvn/version "4.10.0"}
   clojure-msgpack {:mvn/version "1.2.1"}
   camel-snake-kebab {:mvn/version "0.4.0"}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to Conjure
 
+> Note: All development should take place on the develop branch and all pull requests should target it. Merges to master are performed at release time.
+
  1. Check out `CODE_OF_CONDUCT.md`, I will not tolerate behavior that violates that document. Let's all be wonderful humans to each other.
  2. Have a look around the issues to see if something similar to your feature or change has been discussed before.
  3. Speak to someone about it, raise an issue and start a discussion. Of course if you're just fixing a typo then go ahead, but if it's not an entirely trivial change let's work out what to do together. Perhaps someone has already solved your problem and just needs a poke to share their work or findings.

--- a/plugin/conjure.vim
+++ b/plugin/conjure.vim
@@ -106,7 +106,7 @@ endfunction
 " Trigger quick doc ideally because of CursorHold(I).
 " It displays with an echo and is a little context aware.
 function! conjure#quick_doc()
-  call rpcnotify(s:jobid, "quick_doc", expand("<cword>"))
+  call rpcnotify(s:jobid, "quick_doc")
 endfunction
 
 

--- a/plugin/conjure.vim
+++ b/plugin/conjure.vim
@@ -57,8 +57,6 @@ if g:conjure_default_mappings
     autocmd FileType clojure nnoremap <buffer> <localleader>ta :ConjureRunAllTests<cr>
 
     autocmd CursorHold *.edn,*.clj,*.clj[cs] :call conjure#quick_doc()
-    autocmd CursorHoldI *.edn,*.clj,*.clj[cs] :call conjure#quick_doc()
-
     autocmd FileType clojure nnoremap <buffer> K :ConjureDoc <c-r><c-w><cr>
     autocmd FileType clojure nnoremap <buffer> gd :ConjureDefinition <c-r><c-w><cr>
     autocmd FileType clojure setlocal omnifunc=conjure#omnicomplete

--- a/plugin/conjure.vim
+++ b/plugin/conjure.vim
@@ -30,6 +30,7 @@ command! -nargs=1 ConjureLoadFile call rpcnotify(s:jobid, "load_file", <q-args>)
 
 command! -nargs=1 ConjureDefinition call rpcnotify(s:jobid, "definition", <q-args>)
 command! -nargs=1 ConjureDoc call rpcnotify(s:jobid, "doc", <q-args>)
+command! -nargs=1 ConjureHoverDoc call rpcnotify(s:jobid, "hover_doc", <q-args>)
 command! -nargs=0 ConjureOpenLog call rpcnotify(s:jobid, "open_log")
 command! -nargs=0 ConjureCloseLog call rpcnotify(s:jobid, "close_log")
 command! -nargs=* ConjureRunTests call rpcnotify(s:jobid, "run_tests", <q-args>)
@@ -39,17 +40,25 @@ command! -nargs=? ConjureRunAllTests call rpcnotify(s:jobid, "run_all_tests", <q
 if g:conjure_default_mappings
   augroup conjure
     autocmd!
+
     autocmd InsertEnter *.edn,*.clj,*.clj[cs] :call conjure#close_unused_log()
+
     autocmd FileType clojure nnoremap <buffer> <localleader>ee :ConjureEvalCurrentForm<cr>
     autocmd FileType clojure nnoremap <buffer> <localleader>er :ConjureEvalRootForm<cr>
     autocmd FileType clojure vnoremap <buffer> <localleader>ee :ConjureEvalSelection<cr>
     autocmd FileType clojure nnoremap <buffer> <localleader>eb :ConjureEvalBuffer<cr>
     autocmd FileType clojure nnoremap <buffer> <localleader>ef :ConjureLoadFile <c-r>=expand('%:p')<cr><cr>
+
     autocmd FileType clojure nnoremap <buffer> <localleader>cs :ConjureStatus<cr>
     autocmd FileType clojure nnoremap <buffer> <localleader>cl :ConjureOpenLog<cr>
     autocmd FileType clojure nnoremap <buffer> <localleader>cq :ConjureCloseLog<cr>
+
     autocmd FileType clojure nnoremap <buffer> <localleader>tt :ConjureRunTests<cr>
     autocmd FileType clojure nnoremap <buffer> <localleader>ta :ConjureRunAllTests<cr>
+
+    autocmd CursorHold *.edn,*.clj,*.clj[cs] :ConjureHoverDoc <c-r><c-w>
+    autocmd CursorHoldI *.edn,*.clj,*.clj[cs] :ConjureHoverDoc <c-r><c-w>
+
     autocmd FileType clojure nnoremap <buffer> K :ConjureDoc <c-r><c-w><cr>
     autocmd FileType clojure nnoremap <buffer> gd :ConjureDefinition <c-r><c-w><cr>
     autocmd FileType clojure setlocal omnifunc=conjure#omnicomplete

--- a/plugin/conjure.vim
+++ b/plugin/conjure.vim
@@ -1,5 +1,6 @@
 " User config with defaults.
 let g:conjure_default_mappings = get(g:, 'conjure_default_mappings', 1)
+let g:conjure_quick_doc = get(g:, 'conjure_quick_doc', 1)
 let g:conjure_log_direction = get(g:, 'conjure_log_direction', "vertical")
 let g:conjure_log_size_small = get(g:, 'conjure_log_size_small', 25)
 let g:conjure_log_size_large = get(g:, 'conjure_log_size_large', 50)
@@ -56,7 +57,10 @@ if g:conjure_default_mappings
     autocmd FileType clojure nnoremap <buffer> <localleader>tt :ConjureRunTests<cr>
     autocmd FileType clojure nnoremap <buffer> <localleader>ta :ConjureRunAllTests<cr>
 
-    autocmd CursorHold *.edn,*.clj,*.clj[cs] :call conjure#quick_doc()
+    if g:conjure_quick_doc
+      autocmd CursorHold *.edn,*.clj,*.clj[cs] :call conjure#quick_doc()
+    endif
+
     autocmd FileType clojure nnoremap <buffer> K :ConjureDoc <c-r><c-w><cr>
     autocmd FileType clojure nnoremap <buffer> gd :ConjureDefinition <c-r><c-w><cr>
     autocmd FileType clojure setlocal omnifunc=conjure#omnicomplete

--- a/plugin/conjure.vim
+++ b/plugin/conjure.vim
@@ -1,6 +1,5 @@
 " User config with defaults.
 let g:conjure_default_mappings = get(g:, 'conjure_default_mappings', 1)
-let g:conjure_quick_doc = get(g:, 'conjure_quick_doc', 1)
 let g:conjure_log_direction = get(g:, 'conjure_log_direction', "vertical")
 let g:conjure_log_size_small = get(g:, 'conjure_log_size_small', 25)
 let g:conjure_log_size_large = get(g:, 'conjure_log_size_large', 50)
@@ -57,9 +56,7 @@ if g:conjure_default_mappings
     autocmd FileType clojure nnoremap <buffer> <localleader>tt :ConjureRunTests<cr>
     autocmd FileType clojure nnoremap <buffer> <localleader>ta :ConjureRunAllTests<cr>
 
-    if g:conjure_quick_doc
-      autocmd CursorHold *.edn,*.clj,*.clj[cs] :call conjure#quick_doc()
-    endif
+    autocmd CursorHold *.edn,*.clj,*.clj[cs] :call conjure#quick_doc()
 
     autocmd FileType clojure nnoremap <buffer> K :ConjureDoc <c-r><c-w><cr>
     autocmd FileType clojure nnoremap <buffer> gd :ConjureDefinition <c-r><c-w><cr>
@@ -106,7 +103,7 @@ function! conjure#start()
 endfunction
 
 " Trigger quick doc ideally because of CursorHold(I).
-" It displays with an echo and is a little context aware.
+" It displays the doc for the head of the current form using virtual text.
 function! conjure#quick_doc()
   call rpcnotify(s:jobid, "quick_doc")
 endfunction

--- a/plugin/conjure.vim
+++ b/plugin/conjure.vim
@@ -30,7 +30,7 @@ command! -nargs=1 ConjureLoadFile call rpcnotify(s:jobid, "load_file", <q-args>)
 
 command! -nargs=1 ConjureDefinition call rpcnotify(s:jobid, "definition", <q-args>)
 command! -nargs=1 ConjureDoc call rpcnotify(s:jobid, "doc", <q-args>)
-command! -nargs=1 ConjureHoverDoc call rpcnotify(s:jobid, "hover_doc", <q-args>)
+command! -nargs=1 ConjureQuickDoc call conjure#quick_doc()
 command! -nargs=0 ConjureOpenLog call rpcnotify(s:jobid, "open_log")
 command! -nargs=0 ConjureCloseLog call rpcnotify(s:jobid, "close_log")
 command! -nargs=* ConjureRunTests call rpcnotify(s:jobid, "run_tests", <q-args>)
@@ -56,8 +56,8 @@ if g:conjure_default_mappings
     autocmd FileType clojure nnoremap <buffer> <localleader>tt :ConjureRunTests<cr>
     autocmd FileType clojure nnoremap <buffer> <localleader>ta :ConjureRunAllTests<cr>
 
-    autocmd CursorHold *.edn,*.clj,*.clj[cs] :ConjureHoverDoc <c-r><c-w>
-    autocmd CursorHoldI *.edn,*.clj,*.clj[cs] :ConjureHoverDoc <c-r><c-w>
+    autocmd CursorHold *.edn,*.clj,*.clj[cs] :call conjure#quick_doc()
+    autocmd CursorHoldI *.edn,*.clj,*.clj[cs] :call conjure#quick_doc()
 
     autocmd FileType clojure nnoremap <buffer> K :ConjureDoc <c-r><c-w><cr>
     autocmd FileType clojure nnoremap <buffer> gd :ConjureDefinition <c-r><c-w><cr>
@@ -102,6 +102,13 @@ function! conjure#start()
     \})
   endif
 endfunction
+
+" Trigger quick doc ideally because of CursorHold(I).
+" It displays with an echo and is a little context aware.
+function! conjure#quick_doc()
+  call rpcnotify(s:jobid, "quick_doc", expand("<cword>"))
+endfunction
+
 
 " Close the log if we're not currently using it.
 function! conjure#close_unused_log()

--- a/src/conjure/action.clj
+++ b/src/conjure/action.clj
@@ -72,6 +72,22 @@
                          (empty? (:val result))
                          (assoc :val (str "No doc for " name)))})))))
 
+(defn hover-doc [name]
+  (let [ctx (current-ctx {:passive? true})]
+    (some-> (some (fn [conn]
+                    (-> (wrapped-eval ctx
+                                      {:conn conn 
+                                       :code (code/doc-str {:conn conn
+                                                            :name name})})
+                        (get :val)
+                        (result/ok)))
+                  (:conns ctx))
+            (util/split-lines)
+            (->> (rest) (str/join " "))
+            (str/replace #"\s+" " ")
+            (code/sample) ;; TODO Move code/sample to util
+            (nvim/echo))))
+
 (defn eval-current-form []
   (let [{:keys [form origin]} (nvim/read-form)]
     (eval* {:code form

--- a/src/conjure/action.clj
+++ b/src/conjure/action.clj
@@ -98,7 +98,7 @@
                             (get :val)
                             (result/ok))))
                     (:conns ctx))
-              (util/split-lines)
+              (str/split-lines)
               (->> (rest) (str/join " "))
               (str/replace #"\s+" " ")
               (util/sample 50)
@@ -137,7 +137,7 @@
         ;; We read the surrounding top level form from the current buffer
         ;; and add the __prefix__ symbol.
         context (when-let [{:keys [form cursor]} (nvim/read-form {:root? true, :win (:win ctx)})]
-                  (-> (util/split-lines form)
+                  (-> (str/split-lines form)
                       (update (dec (first cursor))
                               #(util/splice %
                                             (- (second cursor) (count prefix))

--- a/src/conjure/action.clj
+++ b/src/conjure/action.clj
@@ -101,7 +101,7 @@
               (util/split-lines)
               (->> (rest) (str/join " "))
               (str/replace #"\s+" " ")
-              (code/sample)
+              (util/sample 50)
               (nvim/echo)))))
 
 (defn eval-current-form []

--- a/src/conjure/action.clj
+++ b/src/conjure/action.clj
@@ -76,8 +76,7 @@
 (defonce previous-quick-doc-form! (atom nil))
 
 (defn quick-doc []
-  ;; TODO Only take parens into account? Could be useful elsewhere with read-form of specific pairs.
-  (let [form (get (nvim/read-form) :form)]
+  (let [form (get (nvim/read-form {:data-pairs? false}) :form)]
     (when (not= form @previous-quick-doc-form!)
       (reset! previous-quick-doc-form! form)
       (when-let [name (some-> (code/parse-code-safe form)

--- a/src/conjure/action.clj
+++ b/src/conjure/action.clj
@@ -76,31 +76,30 @@
 (defonce previous-quick-doc-form! (atom nil))
 
 (defn quick-doc []
-  (let [form (get (nvim/read-form {:data-pairs? false}) :form)]
-    (when (not= form @previous-quick-doc-form!)
-      (reset! previous-quick-doc-form! form)
-      (when-let [name (some-> (code/parse-code-safe form)
-                              (as-> x
-                                (when (seq? x) (first x))
-                                (when (symbol? x) x))
-                              (str))]
-        (let [ctx (current-ctx {:passive? true})
-              resolve-var (code/resolve-var-str name)]
-          (some-> (some (fn [conn]
-                          (when (-> (wrapped-eval ctx {:conn conn, :code resolve-var})
-                                    (get :val)
-                                    (result/ok))
-                            (-> (wrapped-eval ctx {:conn conn
-                                                   :code (code/doc-str {:conn conn
-                                                                        :name name})})
+  (when-let [name (some-> (nvim/read-form {:data-pairs? false})
+                          (get :form)
+                          (code/parse-code-safe)
+                          (as-> x
+                            (when (seq? x) (first x))
+                            (when (symbol? x) x))
+                          (str))]
+    (let [ctx (current-ctx {:passive? true})
+          resolve-var (code/resolve-var-str name)]
+      (some-> (some (fn [conn]
+                      (when (-> (wrapped-eval ctx {:conn conn, :code resolve-var})
                                 (get :val)
-                                (result/ok))))
-                        (:conns ctx))
-                  (str/split-lines)
-                  (->> (rest) (str/join " "))
-                  (str/replace #"\s+" " ")
-                  (util/sample (* (:columns ctx) 0.75))
-                  (nvim/echo)))))))
+                                (result/ok))
+                        (-> (wrapped-eval ctx {:conn conn
+                                               :code (code/doc-str {:conn conn
+                                                                    :name name})})
+                            (get :val)
+                            (result/ok))))
+                    (:conns ctx))
+              (str/split-lines)
+              (->> (rest) (str/join " "))
+              (str/replace #"\s+" " ")
+              (util/sample 256)
+              (nvim/display-virtual)))))
 
 (defn eval-current-form []
   (let [{:keys [form origin]} (nvim/read-form)]

--- a/src/conjure/action.clj
+++ b/src/conjure/action.clj
@@ -74,17 +74,14 @@
                            (assoc :val (str "No doc for " name)))}))))))
 
 (defn quick-doc []
-  ;; TODO Debounce
   ;; TODO Trim the string to the width of the editor (use `columns`)
   ;; TODO Only take parens into account? Could be useful elsewhere with read-form of specific pairs.
-  ;; TODO Don't echo to :messages.
   (when-let [name (some-> (nvim/read-form)
                           (get :form)
                           (code/parse-code-safe)
-                          (first)
                           (as-> x
-                            (when (symbol? x)
-                              x))
+                            (when (seq? x) (first x))
+                            (when (symbol? x) x))
                           (str))]
     (let [ctx (current-ctx {:passive? true})
           resolve-var (code/resolve-var-str name)]

--- a/src/conjure/action.clj
+++ b/src/conjure/action.clj
@@ -95,9 +95,9 @@
                     (:conns ctx))
               (str/split-lines)
               (->> (rest) (str/join " "))
-              (str/replace #"\s+" " ")
               (util/sample 256)
-              (nvim/display-virtual)))))
+              (as-> doc
+                (nvim/display-virtual [[(str ";; " doc) "comment"]]))))))
 
 (defn eval-current-form []
   (let [{:keys [form origin]} (nvim/read-form)]

--- a/src/conjure/action.clj
+++ b/src/conjure/action.clj
@@ -73,8 +73,6 @@
                            (empty? (:val result))
                            (assoc :val (str "No doc for " name)))}))))))
 
-(defonce previous-quick-doc-form! (atom nil))
-
 (defn quick-doc []
   (when-let [name (some-> (nvim/read-form {:data-pairs? false})
                           (get :form)

--- a/src/conjure/action.clj
+++ b/src/conjure/action.clj
@@ -76,6 +76,7 @@
   ;; TODO Debounce
   ;; TODO Trim the string to the width of the editor (use `columns`)
   ;; TODO Only take parens into account? Could be useful elsewhere with read-form of specific pairs.
+  ;; TODO Don't echo to :messages.
   (when-let [name (try
                     (some-> (nvim/read-form)
                             (get :form)

--- a/src/conjure/code.clj
+++ b/src/conjure/code.clj
@@ -45,11 +45,11 @@
                    (map slurp)
                    (str/join "\n"))
               "
-              :ready
+              :conjure/ready
               ")
     :cljs "
           (require 'cljs.repl 'cljs.test)
-          :ready
+          :conjure/ready
           "))
 
 (defn eval-str [{:keys [ns path]} {:keys [conn code line]}]

--- a/src/conjure/code.clj
+++ b/src/conjure/code.clj
@@ -24,10 +24,12 @@
 (defn parse-ns [code]
   (try
     (let [form (parse-code code)]
-      (when (and (seq? form) (= (first form) 'ns))
-        (second (filter symbol? form))))
+      [:ok
+       (when (and (seq? form) (= (first form) 'ns))
+         (second (filter symbol? form)))])
     (catch Throwable e
-      (log/error "Caught error while extracting ns" e))))
+      (log/error "Caught error while extracting ns" e)
+      [:error e])))
 
 (def injected-deps
   "Files to load, in order, to add runtime dependencies to a REPL."

--- a/src/conjure/code.clj
+++ b/src/conjure/code.clj
@@ -177,3 +177,10 @@
            (with-out-str
              (cljs.test/run-all-tests" re-str "))
            "))))
+
+(defn resolve-var-str [name]
+  (if (try (symbol? (parse-code name)) (catch Throwable _))
+    (str "(let [x (resolve '" name ")]
+            (when (var? x)
+              x))")
+    ""))

--- a/src/conjure/code.clj
+++ b/src/conjure/code.clj
@@ -26,7 +26,7 @@
       (log/error "Caught error while extracting ns" e)
       [:error e])))
 
-(def injected-deps
+(def injected-deps!
   "Files to load, in order, to add runtime dependencies to a REPL."
   (delay (edn/read-string (slurp "target/mranderson/load-order.edn"))))
 
@@ -38,7 +38,7 @@
                        'clojure.java.io
                        'clojure.test)
               "
-              (->> (deref injected-deps)
+              (->> @injected-deps!
                    (map slurp)
                    (str/join "\n")) 
               "

--- a/src/conjure/code.clj
+++ b/src/conjure/code.clj
@@ -5,16 +5,6 @@
             [taoensso.timbre :as log]
             [conjure.util :as util]))
 
-(defn sample
-  "Get a short one line sample snippet of some code."
-  [code]
-  (when code
-    (let [sample-length 50
-          flat (str/replace code #"\s+" " ")]
-      (if (> (count flat) sample-length)
-        (str (subs flat 0 sample-length) "…")
-        flat))))
-
 (defn parse-code [code]
   (if (string? code)
     (binding [*default-data-reader-fn* tagged-literal]

--- a/src/conjure/code.clj
+++ b/src/conjure/code.clj
@@ -2,14 +2,16 @@
   "Tools to render or format Clojure code."
   (:require [clojure.string :as str]
             [clojure.edn :as edn]
+            [clojure.tools.reader :as tr]
             [taoensso.timbre :as log]
             [conjure.util :as util]))
 
 (defn parse-code [code]
   (if (string? code)
-    (binding [*read-eval* false
-              *default-data-reader-fn* tagged-literal]
-      (read-string {:read-cond :preserve} code))
+    (binding [tr/*read-eval* false
+              tr/*default-data-reader-fn* tagged-literal
+              tr/*alias-map* (constantly 'user)]
+      (tr/read-string {:read-cond :preserve} code))
     code))
 
 (defn parse-code-safe [code]
@@ -41,7 +43,7 @@
               "
               (->> @injected-deps!
                    (map slurp)
-                   (str/join "\n")) 
+                   (str/join "\n"))
               "
               :ready
               ")

--- a/src/conjure/code.clj
+++ b/src/conjure/code.clj
@@ -7,7 +7,8 @@
 
 (defn parse-code [code]
   (if (string? code)
-    (binding [*default-data-reader-fn* tagged-literal]
+    (binding [*read-eval* false
+              *default-data-reader-fn* tagged-literal]
       (read-string {:read-cond :preserve} code))
     code))
 

--- a/src/conjure/code.clj
+++ b/src/conjure/code.clj
@@ -179,8 +179,6 @@
            "))))
 
 (defn resolve-var-str [name]
-  (if (try (symbol? (parse-code name)) (catch Throwable _))
-    (str "(let [x (resolve '" name ")]
-            (when (var? x)
-              x))")
-    ""))
+  (str "(let [x (resolve '" name ")]
+          (when (var? x)
+            x))"))

--- a/src/conjure/code.clj
+++ b/src/conjure/code.clj
@@ -11,6 +11,11 @@
       (read-string {:read-cond :preserve} code))
     code))
 
+(defn parse-code-safe [code]
+  (try
+    (parse-code code)
+    (catch Throwable _)))
+
 (defn parse-ns [code]
   (try
     (let [form (parse-code code)]

--- a/src/conjure/code.clj
+++ b/src/conjure/code.clj
@@ -9,11 +9,11 @@
   "Get a short one line sample snippet of some code."
   [code]
   (when code
-    (let [sample-length 50]
-      (let [flat (str/replace code #"\s+" " ")]
-        (if (> (count flat) sample-length)
-          (str (subs flat 0 sample-length) "…")
-          flat)))))
+    (let [sample-length 50
+          flat (str/replace code #"\s+" " ")]
+      (if (> (count flat) sample-length)
+        (str (subs flat 0 sample-length) "…")
+        flat))))
 
 (defn parse-code [code]
   (if (string? code)

--- a/src/conjure/main.clj
+++ b/src/conjure/main.clj
@@ -86,8 +86,8 @@
 (defmethod rpc/handle-notify :doc [{:keys [params]}]
   (action/doc (first params)))
 
-(defmethod rpc/handle-notify :hover-doc [{:keys [params]}]
-  (action/hover-doc (first params)))
+(defmethod rpc/handle-notify :quick-doc [{:keys [params]}]
+  (action/quick-doc (first params)))
 
 (defmethod rpc/handle-notify :open-log [_]
   (ui/upsert-log {:focus? true

--- a/src/conjure/main.clj
+++ b/src/conjure/main.clj
@@ -86,8 +86,8 @@
 (defmethod rpc/handle-notify :doc [{:keys [params]}]
   (action/doc (first params)))
 
-(defmethod rpc/handle-notify :quick-doc [{:keys [params]}]
-  (action/quick-doc (first params)))
+(defmethod rpc/handle-notify :quick-doc [_]
+  (action/quick-doc))
 
 (defmethod rpc/handle-notify :open-log [_]
   (ui/upsert-log {:focus? true

--- a/src/conjure/main.clj
+++ b/src/conjure/main.clj
@@ -86,6 +86,9 @@
 (defmethod rpc/handle-notify :doc [{:keys [params]}]
   (action/doc (first params)))
 
+(defmethod rpc/handle-notify :hover-doc [{:keys [params]}]
+  (action/hover-doc (first params)))
+
 (defmethod rpc/handle-notify :open-log [_]
   (ui/upsert-log {:focus? true
                   :resize? true

--- a/src/conjure/nvim.clj
+++ b/src/conjure/nvim.clj
@@ -51,7 +51,7 @@
   "Read the current form under the cursor from the buffer by default. When
   root? is set to true it'll read the outer most form under the cursor."
   ([] (read-form {}))
-  ([{:keys [root? win]}]
+  ([{:keys [root? data-pairs? win] :or {root? false, data-pairs? true}}]
    ;; Put on your seatbelt, this function's a bit wild.
    ;; Could maybe be simplified a little but I doubt that much.
 
@@ -82,8 +82,10 @@
                 (api/get-current-win))
               (api/eval* (str "matchstr(getline('.'), '\\%'.col('.').'c.')"))]
              (get-pair "(" ")")
-             (get-pair "\\[" "\\]")
-             (get-pair "{" "}")))
+             (when data-pairs?
+               (concat
+                 (get-pair "\\[" "\\]")
+                 (get-pair "{" "}")))))
 
          ;; If the position is [0 0] we're _probably_ on the matching
          ;; character, so we should use the cursor position. Don't do this for
@@ -105,7 +107,9 @@
                              end (get-pos end ec)]
                          (when-not (or (nil-pos? start) (nil-pos? end))
                            [start end])))
-                     (->> (interleave positions ["(" ")" "[" "]" "{" "}"])
+                     (->> (interleave positions (concat ["(" ")"]
+                                                        (when data-pairs?
+                                                          ["[" "]" "{" "}"])))
                           (partition 2) (partition 2)))
 
          ;; Pull the lines from the pairs we found.

--- a/src/conjure/nvim.clj
+++ b/src/conjure/nvim.clj
@@ -216,11 +216,11 @@
 (defonce virtual-text-ns!
   (delay (api/call (api/create-namespace :conjure-virtual-text))))
 
-(defn display-virtual [body]
+(defn display-virtual [chunks]
   (let [{:keys [win buf]} (current-ctx)
         [row _] (api/call (api/win-get-cursor win))]
     (api/call-batch
       [(api/buf-clear-namespace buf {:ns-id @virtual-text-ns!})
        (api/buf-set-virtual-text buf {:ns-id @virtual-text-ns!
                                       :line (dec row)
-                                      :chunks [[body "comment"]]})])))
+                                      :chunks chunks})])))

--- a/src/conjure/nvim.clj
+++ b/src/conjure/nvim.clj
@@ -203,4 +203,8 @@
   (api/call (api/set-var :conjure-ready 1)))
 
 (defn echo [& parts]
-  (api/call (api/out-write (str (util/join-words parts) "\n"))))
+  (api/call
+    (api/command
+      (str "echo \""
+           (util/escape-quotes (util/join-words parts))
+           "\""))))

--- a/src/conjure/nvim.clj
+++ b/src/conjure/nvim.clj
@@ -11,12 +11,13 @@
   (let [line-count 25
         buf (api/call (api/get-current-buf))
         get-lines (fn [end] (api/buf-get-lines buf {:start 0, :end end}))
-        [path buf-length sample-lines win]
+        [path buf-length sample-lines win columns]
         (api/call-batch
           [(api/buf-get-name buf)
            (api/buf-line-count buf)
            (get-lines line-count)
-           (api/get-current-win)])]
+           (api/get-current-win)
+           (api/get-option :columns)])]
     (loop [sample-lines sample-lines
            line-count line-count]
       (let [ns-res (code/parse-ns (util/join-lines sample-lines))
@@ -26,7 +27,8 @@
           {:path path
            :buf buf
            :win win
-           :ns (result/ok ns-res)})))))
+           :ns (result/ok ns-res)
+           :columns columns})))))
 
 (defn- read-range
   "Given some lines, start column, and end column it will trim the first and

--- a/src/conjure/nvim.clj
+++ b/src/conjure/nvim.clj
@@ -1,7 +1,8 @@
 (ns conjure.nvim
   (:require [conjure.nvim.api :as api]
             [conjure.code :as code]
-            [conjure.util :as util]))
+            [conjure.util :as util]
+            [conjure.result :as result]))
 
 (defn current-ctx
   "Context contains useful data that we don't watch to fetch twice while
@@ -18,14 +19,14 @@
            (api/get-current-win)])]
     (loop [sample-lines sample-lines
            line-count line-count]
-      (let [ns (code/parse-ns (util/join-lines sample-lines))
+      (let [ns-res (code/parse-ns (util/join-lines sample-lines))
             next-line-count (* line-count 2)]
-        (if (and (nil? ns) (< line-count buf-length))
+        (if (and (result/error? ns-res) (< line-count buf-length))
           (recur (api/call (get-lines next-line-count)) next-line-count)
           {:path path
            :buf buf
            :win win
-           :ns ns})))))
+           :ns (result/ok ns-res)})))))
 
 (defn- read-range
   "Given some lines, start column, and end column it will trim the first and

--- a/src/conjure/nvim.clj
+++ b/src/conjure/nvim.clj
@@ -201,3 +201,6 @@
 
 (defn set-ready! []
   (api/call (api/set-var :conjure-ready 1)))
+
+(defn echo [& parts]
+  (api/call (api/out-write (str (util/join-words parts) "\n"))))

--- a/src/conjure/nvim/api.clj
+++ b/src/conjure/nvim/api.clj
@@ -113,3 +113,7 @@
 (defn feedkeys [{:keys [keys mode escape-csi] :or {mode :m, escape-csi false}}]
   {:method :nvim-feedkeys
    :params [keys (name mode) escape-csi]})
+
+(defn out-write [msg]
+  {:method :nvim-out-write
+   :params [msg]})

--- a/src/conjure/nvim/api.clj
+++ b/src/conjure/nvim/api.clj
@@ -110,6 +110,10 @@
   {:method :nvim-command-output
    :params [expr]})
 
+(defn command [expr]
+  {:method :nvim-command
+   :params [expr]})
+
 (defn feedkeys [{:keys [keys mode escape-csi] :or {mode :m, escape-csi false}}]
   {:method :nvim-feedkeys
    :params [keys (name mode) escape-csi]})

--- a/src/conjure/nvim/api.clj
+++ b/src/conjure/nvim/api.clj
@@ -121,3 +121,15 @@
 (defn out-write [msg]
   {:method :nvim-out-write
    :params [msg]})
+
+(defn create-namespace [name]
+  {:method :nvim-create-namespace
+   :params [(util/kw->snake name)]})
+
+(defn buf-set-virtual-text [buf {:keys [ns-id line chunks opts] :or {opts {}}}]
+  {:method :nvim-buf-set-virtual-text
+   :params [buf ns-id line chunks opts]})
+
+(defn buf-clear-namespace [buf {:keys [ns-id line-start line-end] :or {line-start 0, line-end -1}}]
+  {:method :nvim-buf-clear-namespace
+   :params [buf ns-id line-start line-end]})

--- a/src/conjure/prepl.clj
+++ b/src/conjure/prepl.clj
@@ -55,7 +55,8 @@
   channel. We can use this fact to await the read channel's closure to know
   when the closing is complete. Handy!"
   [{:keys [tag host port]}]
-  (let [[eval-chan read-chan] (repeatedly #(a/chan 32))
+  (let [eval-chan (a/chan)
+        read-chan (a/chan)
         input (PipedInputStream.)
         output (PipedOutputStream. input)]
 
@@ -111,7 +112,7 @@
   (log/info "Adding" tag host port)
   (ui/info "Adding" tag)
 
-  (let [ret-chan (a/chan 32)
+  (let [ret-chan (a/chan)
         conn {:tag tag
               :lang lang
               :host host

--- a/src/conjure/prepl.clj
+++ b/src/conjure/prepl.clj
@@ -130,7 +130,7 @@
     (a/>!! (get-in conn [:chans :eval-chan]) prelude)
 
     (loop []
-      (if (= ":ready" (:val (a/<!! (get-in conn [:chans :read-chan]))))
+      (if (= ":conjure/ready" (:val (a/<!! (get-in conn [:chans :read-chan]))))
         (log/trace "Prelude loaded")
         (recur)))
 

--- a/src/conjure/prepl.clj
+++ b/src/conjure/prepl.clj
@@ -67,7 +67,7 @@
           (server/remote-prepl
             host port reader
             (fn [out]
-              (log/trace "Read from remote-prepl" tag "-" (update out :form code/sample))
+              (log/trace "Read from remote-prepl" tag "-" (update out :form util/sample 20))
               (a/>!! read-chan out))
             :valf identity)
 
@@ -86,7 +86,7 @@
         (try
           (loop []
             (when-let [code (a/<!! eval-chan)]
-              (log/trace "Writing to tag:" tag "-" (code/sample code))
+              (log/trace "Writing to tag:" tag "-" (util/sample code 20))
               (util/write writer code)
               (recur)))
 
@@ -126,7 +126,7 @@
 
     (swap! conns! assoc tag conn)
 
-    (log/trace "Sending prelude:" (code/sample prelude))
+    (log/trace "Sending prelude:" (util/sample prelude 20))
     (a/>!! (get-in conn [:chans :eval-chan]) prelude)
 
     (loop []
@@ -138,7 +138,7 @@
       "read-chan handler"
       (loop []
         (when-let [out (a/<!! (get-in conn [:chans :read-chan]))]
-          (log/trace "Read value from" (:tag conn) "-" (update out :form code/sample))
+          (log/trace "Read value from" (:tag conn) "-" (update out :form util/sample 20))
           (let [out (cond-> out
                       (contains? #{:tap :ret} (:tag out))
                       (update :val code/parse-code))]

--- a/src/conjure/result.clj
+++ b/src/conjure/result.clj
@@ -12,3 +12,17 @@
 (defn value [res]
   (when (result? res)
     (second res)))
+
+(defn error? [res]
+  (= (kind res) :error))
+
+(defn ok? [res]
+  (= (kind res) :ok))
+
+(defn error [res]
+  (when (error? res)
+    (value res)))
+
+(defn ok [res]
+  (when (ok? res)
+    (value res)))

--- a/src/conjure/ui.clj
+++ b/src/conjure/ui.clj
@@ -1,8 +1,8 @@
 (ns conjure.ui
   "Handle displaying and managing what's visible to the user."
-  (:require [conjure.nvim :as nvim]
+  (:require [clojure.string :as str]
+            [conjure.nvim :as nvim]
             [conjure.util :as util]
-            [conjure.code :as code]
             [conjure.result :as result]))
 
 (def ^:private max-log-buffer-length 2000)
@@ -35,7 +35,7 @@
 
   (let [prefix (str "; " (name origin) "/" (name kind))
         log (upsert-log)
-        lines (util/split-lines msg)]
+        lines (str/split-lines msg)]
       (nvim/append-lines
         (merge
           log

--- a/src/conjure/ui.clj
+++ b/src/conjure/ui.clj
@@ -90,8 +90,8 @@
     (append {:origin (:tag conn)
              :kind (:tag resp)
              :code? code?
-             :fold-text (when (and code? (= (result/kind (:val resp)) :error))
-                          "Error folded, use `zo` to reveal")
+             :fold-text (when (and code? (result/error? (:val resp)))
+                          "Error folded")
              :msg (cond-> (:val resp)
                     (= (:tag resp) :ret) (result/value)
                     code? (util/pprint))})))

--- a/src/conjure/ui.clj
+++ b/src/conjure/ui.clj
@@ -80,7 +80,7 @@
   "When we send an eval and are awaiting a result, prints a short sample of the
   code we sent."
   [{:keys [conn code]}]
-  (append {:origin (:tag conn), :kind :eval, :msg (code/sample code)}))
+  (append {:origin (:tag conn), :kind :eval, :msg (util/sample code 50)}))
 
 (defn result
   "Format, if it's code, and display a result from an evaluation.

--- a/src/conjure/util.clj
+++ b/src/conjure/util.clj
@@ -46,7 +46,9 @@
 (defn throwable->str [throwable]
   (-> throwable Throwable->map clj/ex-triage clj/ex-str))
 
-(defn escape-quotes [s]
+(defn escape-quotes
+  "Escape backslashes and double quotes."
+  [s]
   (str/escape s {\\ "\\\\"
                  \" "\\\""}))
 
@@ -62,7 +64,9 @@
 (defn regexp? [o]
   (instance? java.util.regex.Pattern o))
 
-(defn write [stream data]
+(defn write
+  "Write the full data to the stream and then flush the stream."
+  [stream data]
   (doto stream
     (.write data 0 (count data))
     (.flush)))
@@ -99,7 +103,9 @@
         plural? (not= amount 1)]
     (str amount " " description (when plural? "s"))))
 
-(defn free-port []
+(defn free-port
+  "Find a free port we can bind to."
+  []
   (let [socket (java.net.ServerSocket. 0)]
     (.close socket)
     (.getLocalPort socket)))

--- a/src/conjure/util.clj
+++ b/src/conjure/util.clj
@@ -103,18 +103,3 @@
   (let [socket (java.net.ServerSocket. 0)]
     (.close socket)
     (.getLocalPort socket)))
-
-(defn debounce [f ms]
-  (let [in (a/chan (a/sliding-buffer 1))
-        out (a/chan (a/sliding-buffer 1))]
-    (a/go-loop []
-      (let [timeout (a/timeout ms)
-            args (a/<! in)]
-        (a/alt!
-          timeout (a/>! out (apply f args))
-          in nil)
-        (recur)))
-
-    (fn [& args]
-      (a/put! in (or args []))
-      out)))

--- a/src/conjure/util.clj
+++ b/src/conjure/util.clj
@@ -11,9 +11,6 @@
 (defn join-words [parts]
   (str/join " " parts))
 
-(defn split-lines [s]
-  (str/split s #"\n"))
-
 (defn join-lines [lines]
   (str/join "\n" lines))
 

--- a/src/conjure/util.clj
+++ b/src/conjure/util.clj
@@ -26,6 +26,16 @@
        r
        (subs s (min (count s) end))))
 
+(defn sample
+  "Get a one line sample of some string. If the string had to be trimmed an
+  ellipses will be appended onto the end."
+  [code length]
+  (when code
+    (let [flat (str/replace code #"\s+" " ")]
+      (if (> (count flat) length)
+        (str (subs flat 0 length) "…")
+        flat))))
+
 (def ^:dynamic get-env-fn #(System/getenv %))
 
 (defn env

--- a/test/conjure/code_test.clj
+++ b/test/conjure/code_test.clj
@@ -6,6 +6,9 @@
 (t/deftest parse-code
   (t/is (= (code/parse-code "{:foo :bar}") {:foo :bar})))
 
+(t/deftest parse-code-safe
+  (t/is (= (code/parse-code-safe "(ohno(})") nil)))
+
 (t/deftest parse-ns
   (t/is (= (code/parse-ns "lol nope") [:ok nil]))
   (t/is (= (code/parse-ns "(+ 10 10)") [:ok nil]))

--- a/test/conjure/code_test.clj
+++ b/test/conjure/code_test.clj
@@ -1,6 +1,7 @@
 (ns conjure.code-test
   (:require [clojure.test :as t]
-            [conjure.code :as code]))
+            [conjure.code :as code]
+            [conjure.result :as result]))
 
 (t/deftest sample
   (t/is (= (code/sample "this is some code") "this is some code"))
@@ -11,8 +12,9 @@
   (t/is (= (code/parse-code "{:foo :bar}") {:foo :bar})))
 
 (t/deftest parse-ns
-  (t/is (= (code/parse-ns "lol nope") nil))
-  (t/is (= (code/parse-ns "(+ 10 10)") nil))
-  (t/is (= (code/parse-ns "(ns some.ns-woo)") 'some.ns-woo))
-  (t/is (= (code/parse-ns "(ns some.ns-woo \"some docs\")") 'some.ns-woo))
-  (t/is (= (code/parse-ns "(ns ^{:doc \"foo\"} best.ns)") 'best.ns)))
+  (t/is (= (code/parse-ns "lol nope") [:ok nil]))
+  (t/is (= (code/parse-ns "(+ 10 10)") [:ok nil]))
+  (t/is (= (code/parse-ns "(ns some.ns-woo)") [:ok 'some.ns-woo]))
+  (t/is (= (code/parse-ns "(ns some.ns-woo \"some docs\")") [:ok 'some.ns-woo]))
+  (t/is (= (code/parse-ns "(ns ^{:doc \"foo\"} best.ns)") [:ok 'best.ns]))
+  (t/is (result/error? (code/parse-ns "(bad"))))

--- a/test/conjure/code_test.clj
+++ b/test/conjure/code_test.clj
@@ -3,11 +3,6 @@
             [conjure.code :as code]
             [conjure.result :as result]))
 
-(t/deftest sample
-  (t/is (= (code/sample "this is some code") "this is some code"))
-  (t/is (= (code/sample "this is some long code and it exceeds the character limit")
-           "this is some long code and it exceeds the characte…")))
-
 (t/deftest parse-code
   (t/is (= (code/parse-code "{:foo :bar}") {:foo :bar})))
 

--- a/test/conjure/code_test.clj
+++ b/test/conjure/code_test.clj
@@ -7,6 +7,7 @@
   (t/is (= (code/parse-code "{:foo :bar}") {:foo :bar})))
 
 (t/deftest parse-code-safe
+  (t/is (= (code/parse-code "{:foo :bar}") {:foo :bar}))
   (t/is (= (code/parse-code-safe "(ohno(})") nil)))
 
 (t/deftest parse-ns

--- a/test/conjure/nvim_test.clj
+++ b/test/conjure/nvim_test.clj
@@ -29,14 +29,12 @@
   (defmethod call :nvim-buf-get-lines [{[buf] :params}]
     (t/is (= buf 5))
     ["(ns foo)"])
-  (defmethod call :nvim-get-option [_] 300)
 
   (t/is (= (nvim/current-ctx)
            {:path "foo.clj"
             :buf 5
             :win 10
-            :ns 'foo
-            :columns 300})))
+            :ns 'foo})))
 
 (t/deftest read-form
   (let [src ["(+ 10 10)"

--- a/test/conjure/nvim_test.clj
+++ b/test/conjure/nvim_test.clj
@@ -29,12 +29,14 @@
   (defmethod call :nvim-buf-get-lines [{[buf] :params}]
     (t/is (= buf 5))
     ["(ns foo)"])
+  (defmethod call :nvim-get-option [_] 300)
 
   (t/is (= (nvim/current-ctx)
            {:path "foo.clj"
             :buf 5
             :win 10
-            :ns 'foo})))
+            :ns 'foo
+            :columns 300})))
 
 (t/deftest read-form
   (let [src ["(+ 10 10)"

--- a/test/conjure/result_test.clj
+++ b/test/conjure/result_test.clj
@@ -13,3 +13,19 @@
   (t/is (= (result/value [1 2 3]) nil))
   (t/is (= (result/value ["foo" :bar]) nil))
   (t/is (= (result/value [:foo :bar]) :bar)))
+
+(t/deftest error?
+  (t/is (result/error? [:error :ohno]))
+  (t/is (not (result/error? [:ok :yay]))))
+
+(t/deftest ok?
+  (t/is (result/ok? [:ok :yay]))
+  (t/is (not (result/ok? [:error :ohno]))))
+
+(t/deftest error
+  (t/is (= (result/error [:error :ohno]) :ohno))
+  (t/is (= (result/error [:ok :yay]) nil)))
+
+(t/deftest ok
+  (t/is (= (result/ok [:ok :yay]) :yay))
+  (t/is (= (result/ok [:error :ohno]) nil)))

--- a/test/conjure/util_test.clj
+++ b/test/conjure/util_test.clj
@@ -74,16 +74,3 @@
 
 (t/deftest thread
   (t/is (= @(util/thread "adding" (+ 10 10)) 20)))
-
-(t/deftest debounce
-  (t/testing "waiting on a single debounced value"
-    (let [f (util/debounce inc 5)]
-      (t/is (= (a/<!! (f 10)) 11))))
-
-  (t/testing "multiple calls are debounced"
-    (let [v (atom 0)
-          f (util/debounce (fn [] (swap! v inc)) 5)]
-      (f) (f) (f)
-      (t/is (= @v 0))
-      (a/<!! (f))
-      (t/is (= @v 1)))))

--- a/test/conjure/util_test.clj
+++ b/test/conjure/util_test.clj
@@ -1,5 +1,6 @@
 (ns conjure.util-test
   (:require [clojure.test :as t]
+            [clojure.core.async :as a]
             [zprint.core :as zp]
             [conjure.util :as util]))
 
@@ -73,3 +74,16 @@
 
 (t/deftest thread
   (t/is (= @(util/thread "adding" (+ 10 10)) 20)))
+
+(t/deftest debounce
+  (t/testing "waiting on a single debounced value"
+    (let [f (util/debounce inc 5)]
+      (t/is (= (a/<!! (f 10)) 11))))
+
+  (t/testing "multiple calls are debounced"
+    (let [v (atom 0)
+          f (util/debounce (fn [] (swap! v inc)) 5)]
+      (f) (f) (f)
+      (t/is (= @v 0))
+      (a/<!! (f))
+      (t/is (= @v 1)))))

--- a/test/conjure/util_test.clj
+++ b/test/conjure/util_test.clj
@@ -8,10 +8,6 @@
   (t/is (= (util/join-words []) ""))
   (t/is (= (util/join-words ["foo" "bar"]) "foo bar")))
 
-(t/deftest split-lines
-  (t/is (= (util/split-lines "") [""]))
-  (t/is (= (util/split-lines "foo\nbar") ["foo" "bar"])))
-
 (t/deftest join-lines
   (t/is (= (util/join-lines []) ""))
   (t/is (= (util/join-lines ["foo" "bar"]) "foo\nbar")))

--- a/test/conjure/util_test.clj
+++ b/test/conjure/util_test.clj
@@ -27,6 +27,10 @@
     (t/is (= (util/splice "" -1 0 "") ""))
     (t/is (= (util/splice "Hello, World!" 7 20 "Conjure?") "Hello, Conjure?"))))
 
+(t/deftest sample
+  (t/is (= (util/sample "this is some code" 20) "this is some code"))
+  (t/is (= (util/sample "this is some long code" 20) "this is some long co…")))
+
 (t/deftest escape-quotes
   (t/is (= (util/escape-quotes "\"\"") "\\\"\\\"")))
 


### PR DESCRIPTION
This addresses #32, so now when `CursorHold` fires you'll see a snippet of the documentation for the current form's head symbol in the echo messages area.

You can control the delay with `set updatetime=500` for a 500ms delay before it looks anything up. I need to use it for a while to make sure it doesn't cause weird errors preventing you from typing, that'll be super annoying.

Feel free to give this branch a whirl!

## To Do

 * [x] Work out why some macro forms don't get doc - **reason**: `read-string` doesn't like autoresolved maps and keywords like `::q/foo` or `#::q/foo{...}`. We can't read those strings without having all of the aliases defined from the target namespace - **fix**: Use `tools.reader` with some extra options so we can parse more code.
 * [x] Reproduce and fix the root cause of the rare error where `split-lines` is called on a `Cons` instead of a `String`. (have only seen this once or twice, may have fixed it by mistake...) - **reason**: Looks like it's because the doc lookup call is coming in while the prelude is still evaluating which is a bit weird - **fix**: I guess block these evaluations until everything is done?

## Maybe Eventually

 * Get it working in insert mode, `CursorHoldI` seems kinda broken in Neovim https://github.com/neovim/neovim/issues/3757 (might have to implement my own debounce)
 * Standardise for doc and quick doc that it tries to check the symbol under the cursor _and then_ the head of the current form.
 * Allow doc of keywords if they contain specs. (should really be var, special form or spec keyword)