### PR TITLE
Virtual text eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The `'for'` and `'on'` keys are optional but you might prefer Conjure to only st
 You can disable these and define your own with `let g:conjure_default_mappings = 0`.
 
  * `InsertEnter` in a Clojure buffer (that is _not_ the log) closes the log.
- * `CursorHold` in a Clojure buffer looks up the docs for the head of the form under your cursor and displays it with virtual text.
+ * `CursorMoved(I)` in a Clojure buffer looks up the docs for the head of the form under your cursor and displays it with virtual text.
  * `<localleader>ee` - `ConjureEvalCurrentForm`
  * `<localleader>er` - `ConjureEvalRootForm`
  * `<localleader>ee` - `ConjureEvalSelection` (visual mode)

--- a/lua/conjure.lua
+++ b/lua/conjure.lua
@@ -60,12 +60,12 @@ function conjure.upsert_log(log_buf_name, size, focus, resize, open)
   local size_abs = get_log_window_size(size, direction)
   local match = find_log_buf_and_win(log_buf_name) or find_log_buf(log_buf_name)
 
-  if match then
-    if open and focus == true then
+  if match and match.win and open then
+    if focus == true then
       vim.api.nvim_set_current_win(match.win)
     end
 
-    if open and resize == true then
+    if resize == true then
       if direction == "horizontal" then
         vim.api.nvim_win_set_height(match.win, size_abs)
       else
@@ -73,6 +73,8 @@ function conjure.upsert_log(log_buf_name, size, focus, resize, open)
       end
     end
 
+    return match
+  elseif match and not open then
     return match
   else
     local split = (direction == "horizontal") and "split" or "vsplit"

--- a/plugin/conjure.vim
+++ b/plugin/conjure.vim
@@ -56,7 +56,8 @@ if g:conjure_default_mappings
     autocmd FileType clojure nnoremap <buffer> <localleader>tt :ConjureRunTests<cr>
     autocmd FileType clojure nnoremap <buffer> <localleader>ta :ConjureRunAllTests<cr>
 
-    autocmd CursorHold *.edn,*.clj,*.clj[cs] :call conjure#quick_doc()
+    autocmd CursorMoved *.edn,*.clj,*.clj[cs] :call conjure#quick_doc()
+    autocmd CursorMovedI *.edn,*.clj,*.clj[cs] :call conjure#quick_doc()
 
     autocmd FileType clojure nnoremap <buffer> K :ConjureDoc <c-r><c-w><cr>
     autocmd FileType clojure nnoremap <buffer> gd :ConjureDefinition <c-r><c-w><cr>
@@ -102,14 +103,18 @@ function! conjure#start()
   endif
 endfunction
 
-" Trigger quick doc ideally because of CursorHold(I).
+" Trigger quick doc on CursorMoved(I) with a debounce.
 " It displays the doc for the head of the current form using virtual text.
+let s:quick_doc_timer = -1
 function! conjure#quick_doc()
   if g:conjure_ready
-    call rpcnotify(s:jobid, "quick_doc")
+    if s:quick_doc_timer != -1
+      call timer_stop(s:quick_doc_timer)
+    endif
+
+    let s:quick_doc_timer = timer_start(250, {-> rpcnotify(s:jobid, "quick_doc")})
   endif
 endfunction
-
 
 " Close the log if we're not currently using it.
 function! conjure#close_unused_log()

--- a/src/conjure/action.clj
+++ b/src/conjure/action.clj
@@ -73,7 +73,6 @@
                            (empty? (:val result))
                            (assoc :val (str "No doc for " name)))}))))))
 
-;; TODO Prevent this from overriding one line eval results.
 (defn quick-doc []
   (when-let [name (some-> (nvim/read-form {:data-pairs? false})
                           (get :form)

--- a/src/conjure/action.clj
+++ b/src/conjure/action.clj
@@ -73,6 +73,7 @@
                            (empty? (:val result))
                            (assoc :val (str "No doc for " name)))}))))))
 
+;; TODO Prevent this from overriding one line eval results.
 (defn quick-doc []
   (when-let [name (some-> (nvim/read-form {:data-pairs? false})
                           (get :form)

--- a/src/conjure/nvim.clj
+++ b/src/conjure/nvim.clj
@@ -200,7 +200,10 @@
 
        ;; Insert the new lines and scroll to the bottom.
        (api/buf-set-lines buf {:start -1, :end -1} lines)
-       (api/win-set-cursor win {:col 0, :row new-line-count})])
+
+       (if win
+         (api/win-set-cursor win {:col 0, :row new-line-count})
+         (api/command "redraw!"))])
     nil))
 
 (defn set-ready! []

--- a/src/conjure/ui.clj
+++ b/src/conjure/ui.clj
@@ -12,13 +12,15 @@
 (defn upsert-log
   "Get, create, or update the log window and buffer."
   ([] (upsert-log {}))
-  ([{:keys [focus? resize? size] :or {focus? false, resize? false, size :small}}]
+  ([{:keys [focus? resize? open? size]
+     :or {focus? false, resize? false, open? true, size :small}}]
    (-> (nvim/call-lua-function
          :upsert-log
          log-buffer-name
          (util/kw->snake size)
          focus?
-         resize?)
+         resize?
+         open?)
        (util/snake->kw-map))))
 
 (defn close-log
@@ -31,10 +33,10 @@
   then it won't prefix every line with the source, it'll place the whole string
   below the origin/kind comment. If you provide fold-text the lines will be
   wrapped with fold markers and automatically hidden with your text displayed instead."
-  [{:keys [origin kind msg code? fold-text] :or {code? false}}]
+  [{:keys [origin kind msg code? fold-text open?] :or {code? false, open? true}}]
 
   (let [prefix (str "; " (name origin) "/" (name kind))
-        log (upsert-log)
+        log (upsert-log {:open? open?})
         lines (str/split-lines msg)]
       (nvim/append-lines
         (merge
@@ -80,7 +82,10 @@
   "When we send an eval and are awaiting a result, prints a short sample of the
   code we sent."
   [{:keys [conn code]}]
-  (append {:origin (:tag conn), :kind :eval, :msg (util/sample code 50)}))
+  (append {:origin (:tag conn)
+           :kind :eval
+           :msg (util/sample code 50)
+           :open? false}))
 
 (defn result
   "Format, if it's code, and display a result from an evaluation.
@@ -90,6 +95,7 @@
     (append {:origin (:tag conn)
              :kind (:tag resp)
              :code? code?
+             :open? false
              :fold-text (when (and code? (result/error? (:val resp)))
                           "Error folded")
              :msg (cond-> (:val resp)


### PR DESCRIPTION
So this has been mentioned a few times and here's the initial implementation! I also improved the quick doc virtual text and how it behaves. Now as you type (even in insert mode) you'll see quick doc, if you eval something (file, buffer, form _or_ root form) and it results in a single line output it'll appear as virtual text. The log buffer **will not open**.

You can still open it of course and it'll contain your history of evals, it'll also still open if there's more than one line in the output. I think this is a good middleground that will stop a bunch of window jank (where they pop in and out as you edit) just for one line results.

It takes up the same virtual text space as quick doc, so now you can always have the useful contextual information just at the end of your current line with a full log buffer a couple of key presses away. I hope you enjoy! I'm looking forward to using this myself :smile: :tada: