### PR TITLE
Declaritive prepl connections

### DIFF
--- a/.conjure.edn
+++ b/.conjure.edn
@@ -1,0 +1,4 @@
+{:conns
+ {:dev {:port 5885}
+  :jvm {:port 5555}
+  :node {:port 5556}}}

--- a/.conjure.edn
+++ b/.conjure.edn
@@ -1,4 +1,5 @@
 {:conns
  {:dev {:port 5885}
   :jvm {:port 5555}
-  :node {:port 5556}}}
+  :node {:port 5556
+         :lang :cljs}}}

--- a/.conjure.edn
+++ b/.conjure.edn
@@ -1,5 +1,4 @@
 {:conns
  {:dev {:port 5885}
   :jvm {:port 5555}
-  :node {:port 5556
-         :lang :cljs}}}
+  :node {:port 5556, :lang :cljs}}}

--- a/.lvimrc
+++ b/.lvimrc
@@ -1,9 +1,3 @@
-nnoremap <localleader>cc :ConjureAdd {:tag :dev, :port 5885}<cr>
-nnoremap <localleader>cC 
-      \:ConjureAdd {:tag :jvm, :port 5555}<cr>
-      \:ConjureAdd {:tag :node, :port 5556, :lang :cljs}<cr>
-      " \:ConjureAdd {:tag :browser, :port 5557, :lang :cljs}<cr>
-
 let &runtimepath=resolve(expand("<sfile>:p:h")) . "," . &runtimepath
 lua package.loaded["conjure"] = nil
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can find out more about socket prepls in my blog post, [Clojure socket prepl
 Here's an example with [vim-plug][], my plugin manager of choice.
 
 ```viml
-Plug 'Olical/conjure', { 'tag': 'v0.17.1', 'do': 'bin/compile', 'for': 'clojure'  }
+Plug 'Olical/conjure', { 'tag': 'v0.17.1', 'do': 'bin/compile', 'for': 'clojure', 'on': 'ConjureUp'  }
 ```
 
 You should rely on a tag so that breaking changes don't end up disrupting your workflow, please don't depend on `master` (and especially not `develop`!). Make sure you watch the repository for releases using the menu in the top right, that way you can upgrade when it's convenient for you.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,23 @@ Here's an exhaustive example of what you can configure with these files. If you 
 
 If you open Conjure without any connections configured it'll self prepl into it's _own_ JVM. This allows you to have autocompletion and evaluation in any directory or Clojure file. This can be really useful for quickly trying something out in a temporary file where a regular REPL won't quite cut it.
 
+### Commands
+
+ * `ConjureUp` - synchronise connections with your `.conjure.edn` config files.
+ * `ConjureStatus` - display the current connections in the log buffer.
+ * `ConjureEval` - evaluate the argument as Clojure code.
+ * `ConjureEvalSelection` - evaluates the current (or previous) visual selection.
+ * `ConjureEvalCurrentForm` - evaluates the form under the cursor.
+ * `ConjureEvalRootForm` - evaluates the outermost form under the cursor.
+ * `ConjureEvalBuffer` - evaluate the entire buffer (not from the disk).
+ * `ConjureLoadFile` - load and evaluate the file from the disk.
+ * `ConjureDoc` - display the documentation for the given symbol in the log buffer.
+ * `ConjureDefinition` - go to the source of the given symbol, providing we can find it - falls back to vanilla `gd`.
+ * `ConjureOpenLog` - open and focus the log buffer in a wide window.
+ * `ConjureCloseLog` - close the log window if it's open in this tab.
+ * `ConjureRunTests` - run tests in the current namespace and it's `-test` equivalent (as well as the other way around) or with the provided namespace names separated by spaces.
+ * `ConjureRunAllTests` - run all tests with an optional namespace filter regex.
+
 ### Mappings
 
  * `InsertEnter` in a Clojure buffer (that is _not_ the log) closes the log.
@@ -89,23 +106,6 @@ If you open Conjure without any connections configured it'll self prepl into it'
  * `<localleader>ta` - `ConjureRunAllTests`
  * `K` - `ConjureDoc`
  * `gd` - `ConjureDefinition`
-
-### Commands
-
- * `ConjureUp` - synchronise connections with your `.conjure.edn` config files.
- * `ConjureStatus` - display the current connections in the log buffer.
- * `ConjureEval` - evaluate the argument as Clojure code.
- * `ConjureEvalSelection` - evaluates the current (or previous) visual selection.
- * `ConjureEvalCurrentForm` - evaluates the form under the cursor.
- * `ConjureEvalRootForm` - evaluates the outermost form under the cursor.
- * `ConjureEvalBuffer` - evaluate the entire buffer (not from the disk).
- * `ConjureLoadFile` - load and evaluate the file from the disk.
- * `ConjureDoc` - display the documentation for the given symbol in the log buffer.
- * `ConjureDefinition` - go to the source of the given symbol, providing we can find it - falls back to vanilla `gd`.
- * `ConjureOpenLog` - open and focus the log buffer in a wide window.
- * `ConjureCloseLog` - close the log window if it's open in this tab.
- * `ConjureRunTests` - run tests in the current namespace and it's `-test` equivalent (as well as the other way around) or with the provided namespace names separated by spaces.
- * `ConjureRunAllTests` - run all tests with an optional namespace filter regex.
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ You can find out more about socket prepls in my blog post, [Clojure socket prepl
  * Friendly error output by default with optional expansion.
  * Go to definition.
  * Documentation lookup on a key press and when your cursor is idle.
+ * Declarative prepl connections with `.conjure.edn`.
 
 ### Upcoming for v1.0.0
 
- * Declarative prepl connections. ([#15](https://github.com/Olical/conjure/issues/15))
  * Code formatting. ([#11](https://github.com/Olical/conjure/issues/11))
  * Changed namespace reloading via `tools.namespace`. ([#10](https://github.com/Olical/conjure/issues/10))
  * Polished documentation and README. ([#6](https://github.com/Olical/conjure/issues/6))
@@ -31,14 +31,46 @@ You can find out more about socket prepls in my blog post, [Clojure socket prepl
 Here's an example with [vim-plug][], my plugin manager of choice.
 
 ```viml
-Plug 'Olical/conjure', { 'tag': 'v0.17.1', 'do': 'bin/compile', 'for': 'clojure', 'on': 'ConjureAdd'  }
+Plug 'Olical/conjure', { 'tag': 'v0.17.1', 'do': 'bin/compile', 'for': 'clojure'  }
 ```
 
 You should rely on a tag so that breaking changes don't end up disrupting your workflow, please don't depend on `master` (and especially not `develop`!). Make sure you watch the repository for releases using the menu in the top right, that way you can upgrade when it's convenient for you.
 
-The `'for'` and `'on'` keys are optional but you might prefer Conjure to only start up once you've entered a Clojure file.
-
 ## Usage
+
+### Configuration
+
+Connections are configured through the `.conjure.edn` file in your current directory, which is deeply merged with all other `.conjure.edn` files in all parent directories. This allows you to store common settings for your workflow in your home directory, for example.
+
+Once you're set up you can execute `ConjureUp` (`<localleader>cu` by default) to read, merge and validate all of your files. `ConjureUp` is also executed when Conjure starts, so you can just open any Clojure file and start hacking. The files in your local directory will overwrite those in parent directories allowing you to override things in your home directory.
+
+Here's an exhaustive example of what you can configure with these files. If you get something wrong you'll get an explanation from [expound][].
+
+```clojure
+{:conns
+ {:api {:port 5885}
+  :frontend {:port 5556
+
+             ;; You need to explicitly tell Conjure if it's a ClojureScript connection.
+             :lang :cljs}
+
+  :staging {:host "foo.com"
+            :port 424242
+
+            ;; This is EDN so you need to specify that you want a regex.
+            ;; Clojure(Script)'s #"..." syntax won't work here.
+            :expr #regex "\\.(cljc?|edn|another.extension)$"}
+
+  ;; You can slurp in valid EDN which allows you to use random port files from other tools (such as boot).
+  :boot {:port #slurp-edn ".socket-port"
+
+         ;; Disabled conns will be ignored on ConjureUp.
+         ;; They can be enabled and disabled with `:ConjureUp -staging +boot`
+         ;; This allows you to toggle parts of your config with different custom mappings.
+         :enabled? false}}}
+```
+
+If you open Conjure without any connections configured it'll self prepl into it's _own_ JVM. This allows you to have autocompletion and evaluation in any directory or Clojure file. This can be really useful for quickly trying something out in a temporary file where a regular REPL won't quite cut it.
 
 ### Mappings
 
@@ -49,6 +81,7 @@ The `'for'` and `'on'` keys are optional but you might prefer Conjure to only st
  * `<localleader>ee` - `ConjureEvalSelection` (visual mode)
  * `<localleader>eb` - `ConjureEvalBuffer`
  * `<localleader>ef` - `ConjureLoadFile`
+ * `<localleader>cu` - `ConjureUp`
  * `<localleader>cs` - `ConjureStatus`
  * `<localleader>cl` - `ConjureOpenLog`
  * `<localleader>cq` - `ConjureCloseLog`
@@ -59,9 +92,7 @@ The `'for'` and `'on'` keys are optional but you might prefer Conjure to only st
 
 ### Commands
 
- * `ConjureAdd` - add a new connection.
- * `ConjureRemove` - remove an existing connection by tag.
- * `ConjureRemoveAll` - remove all connections.
+ * `ConjureUp` - synchronise connections with your `.conjure.edn` config files.
  * `ConjureStatus` - display the current connections in the log buffer.
  * `ConjureEval` - evaluate the argument as Clojure code.
  * `ConjureEvalSelection` - evaluates the current (or previous) visual selection.
@@ -75,20 +106,6 @@ The `'for'` and `'on'` keys are optional but you might prefer Conjure to only st
  * `ConjureCloseLog` - close the log window if it's open in this tab.
  * `ConjureRunTests` - run tests in the current namespace and it's `-test` equivalent (as well as the other way around) or with the provided namespace names separated by spaces.
  * `ConjureRunAllTests` - run all tests with an optional namespace filter regex.
-
-`ConjureAdd` takes a map that conforms to the following spec.
-
-```clojure
-(s/def ::expr util/regexp?)
-(s/def ::tag keyword?)
-(s/def ::port number?)
-(s/def ::lang #{:clj :cljs})
-(s/def ::host string?)
-(s/def ::new-conn (s/keys :req-un [::tag ::port]
-                          :opt-un [::expr ::lang ::host]))
-```
-
-If you get something wrong it'll explain using [Expound][] in the log buffer. Essentially you must provide at least a `:tag` and `:port`.
 
 ### Options
 
@@ -127,31 +144,6 @@ let g:deoplete#keyword_patterns.clojure = '[\w!$%&*+/:<=>?@\^_~\-\.#]*'
 #### [Coc][]
 
 You can install [coc-conjure][] to hook these two tools together easily, all thanks to [@jlesquembre][]. Documentation for that process can be found inside the repository.
-
-## Example
-
-> Note: Hopefully all of the stateful `ConjureAdd` / `ConjureRemove` commands will vanish with #15!
-
-```viml
-" A regular Clojure connection.
-:ConjureAdd {:tag :jvm, :port 5555}
-
-" The :lang defaults to :clj, you need to specify it as :cljs for ClojureScript.
-:ConjureAdd {:tag :node, :port 5556, :lang :cljs}
-
-" This will print the result from both REPLs
-" Providing you call it from within a .cljc buffer.
-:ConjureEval (+ 10 10)
-
-" Disconnect from :node.
-:ConjureRemove :node
-```
-
-If you wish to change the regular expression used to match buffers to connections, you can set `:expr`. You need to prefix it with `#regex` because [edn][] doesn't have built in support for `#"..."` syntax like Clojure does.
-
-```viml
-:ConjureAdd {:tag :frontend, :port 8888, :expr #regex "frontend/.+\\.cljs", :lang :cljs}
-```
 
 ## Unlicenced
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If you open Conjure without any connections configured it'll self prepl into it'
 
 ### Commands
 
- * `ConjureUp` - synchronise connections with your `.conjure.edn` config files.
+ * `ConjureUp` - synchronise connections with your `.conjure.edn` config files, takes flags like `-foo +bar` which will set the `:enabled?` flags of matching connections.
  * `ConjureStatus` - display the current connections in the log buffer.
  * `ConjureEval` - evaluate the argument as Clojure code.
  * `ConjureEvalSelection` - evaluates the current (or previous) visual selection.

--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,8 @@
   tcp-server {:mvn/version "0.1.0"}
   cheshire {:mvn/version "5.8.1"}
   me.raynes/fs {:mvn/version "1.4.6"}
-  medley {:mvn/version "1.2.0"}}
+  medley {:mvn/version "1.2.0"}
+  traversy {:mvn/version "0.5.0"}}
 
  :aliases
  {:test

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,9 @@
   expound {:mvn/version "0.7.2"}
   zprint {:mvn/version "0.4.15"}
   tcp-server {:mvn/version "0.1.0"}
-  cheshire {:mvn/version "5.8.1"}}
+  cheshire {:mvn/version "5.8.1"}
+  me.raynes/fs {:mvn/version "1.4.6"}
+  medley {:mvn/version "1.2.0"}}
 
  :aliases
  {:test

--- a/plugin/conjure.vim
+++ b/plugin/conjure.vim
@@ -22,9 +22,7 @@ else
 endif
 
 " Create commands for RPC calls handled by main.clj.
-command! -nargs=1 ConjureAdd call conjure#notify("add", <q-args>)
-command! -nargs=1 ConjureRemove call conjure#notify("remove", <q-args>)
-command! -nargs=0 ConjureRemoveAll call conjure#notify("remove_all")
+command! -nargs=0 ConjureUp call conjure#notify("up")
 command! -nargs=0 ConjureStatus call conjure#notify("status")
 
 command! -nargs=1 ConjureEval call conjure#notify("eval", <q-args>)
@@ -52,6 +50,7 @@ augroup conjure
     autocmd FileType clojure nnoremap <buffer> <localleader>eb :ConjureEvalBuffer<cr>
     autocmd FileType clojure nnoremap <buffer> <localleader>ef :ConjureLoadFile <c-r>=expand('%:p')<cr><cr>
 
+    autocmd FileType clojure nnoremap <buffer> <localleader>cu :ConjureUp<cr>
     autocmd FileType clojure nnoremap <buffer> <localleader>cs :ConjureStatus<cr>
     autocmd FileType clojure nnoremap <buffer> <localleader>cl :ConjureOpenLog<cr>
     autocmd FileType clojure nnoremap <buffer> <localleader>cq :ConjureCloseLog<cr>
@@ -206,4 +205,8 @@ endfunction
 " version and override it with the development version temporarily.
 if $CONJURE_ALLOWED_DIR == "" || $CONJURE_ALLOWED_DIR == s:cwd
   call conjure#start()
+
+  " Perform an initial ConjureUp which will read the user config and attempt
+  " to connect to everything available.
+  ConjureUp
 endif

--- a/plugin/conjure.vim
+++ b/plugin/conjure.vim
@@ -22,7 +22,7 @@ else
 endif
 
 " Create commands for RPC calls handled by main.clj.
-command! -nargs=0 ConjureUp call conjure#notify("up")
+command! -nargs=* ConjureUp call conjure#notify("up", <q-args>)
 command! -nargs=0 ConjureStatus call conjure#notify("status")
 
 command! -nargs=1 ConjureEval call conjure#notify("eval", <q-args>)

--- a/src/conjure/action.clj
+++ b/src/conjure/action.clj
@@ -14,10 +14,6 @@
   "An enriched version of the nvim ctx with matching prepl connections."
   ([] (current-ctx {}))
   ([{:keys [passive?] :or {passive? false}}]
-   (when (and (not passive?) (empty? (prepl/conns)))
-     (ui/info "Warning: Connecting to Conjure's own JVM by default.\nYou should start your own prepl and connect to that.")
-     (prepl/add! {:tag :conjure, :port prepl/internal-port}))
-
    (let [ctx (nvim/current-ctx)
          conns (prepl/conns (:path ctx))]
 

--- a/src/conjure/config.clj
+++ b/src/conjure/config.clj
@@ -15,7 +15,8 @@
 (s/def ::lang #{:clj :cljs})
 (s/def ::host string?)
 (s/def ::tag keyword?)
-(s/def ::conn (s/keys :req-un [::port ::host ::lang ::expr]))
+(s/def ::enabled? boolean?)
+(s/def ::conn (s/keys :req-un [::port ::host ::lang ::expr ::enabled?]))
 (s/def ::conns (s/map-of ::tag ::conn))
 (s/def ::config (s/nilable (s/keys :opt-un [::conns])))
 
@@ -47,7 +48,8 @@
                  (fn [conn]
                    (merge {:lang :clj
                            :expr (get default-exprs (get conn :lang :clj))
-                           :host "127.0.0.1"}
+                           :host "127.0.0.1"
+                           :enabled? true}
                           conn)))))
 
 (defn- validate

--- a/src/conjure/config.clj
+++ b/src/conjure/config.clj
@@ -7,6 +7,7 @@
             [medley.core :as m]
             [me.raynes.fs :as fs]
             [traversy.lens :as tl]
+            [conjure.ui :as ui]
             [conjure.util :as util]))
 
 (s/def ::expr util/regexp?)
@@ -22,7 +23,7 @@
   {:clj #"\.(cljc?|edn)$"
    :cljs #"\.(clj(s|c)|edn)$"})
 
-(def edn-opts
+(def ^:private edn-opts
   {:readers {'regex re-pattern
              'slurp-edn (comp edn/read-string slurp)}})
 
@@ -54,8 +55,8 @@
   [config]
   (if (s/valid? ::config config)
     config
-    (throw (Error. (str "Conjure config failed spec.\n\n"
-                        (expound/expound-str ::config config))))))
+    (ui/error (str "Something's wrong with your .conjure.edn!\n"
+                   (expound/expound-str ::config config)))))
 
 (defn fetch
   "Gather, hydrate and validate the config."
@@ -63,6 +64,3 @@
   (-> (gather)
       (hydrate)
       (validate)))
-
-(comment
-  (time (fetch)))

--- a/src/conjure/config.clj
+++ b/src/conjure/config.clj
@@ -72,7 +72,7 @@
                             \- false
                             \+ true
                             nil) }))
-        (remove (comp nil? second)))
+        (remove (comp nil? :enabled?)))
       (completing
         (fn [config {:keys [tag enabled?]}]
           (tl/update config (tl/in [:conns tag])

--- a/src/conjure/config.clj
+++ b/src/conjure/config.clj
@@ -2,20 +2,67 @@
   "Tools to load all relevant  .conjure.edn files.
   They're used to manage connection configuration."
   (:require [clojure.edn :as edn]
+            [clojure.spec.alpha :as s]
+            [expound.alpha :as expound]
             [medley.core :as m]
-            [me.raynes.fs :as fs]))
+            [me.raynes.fs :as fs]
+            [traversy.lens :as tl]
+            [conjure.util :as util]))
+
+(s/def ::expr util/regexp?)
+(s/def ::port number?)
+(s/def ::lang #{:clj :cljs})
+(s/def ::host string?)
+(s/def ::tag keyword?)
+(s/def ::conn (s/keys :req-un [::port ::host ::lang ::expr]))
+(s/def ::conns (s/map-of ::tag ::conn))
+(s/def ::config (s/nilable (s/keys :opt-un [::conns])))
+
+(def ^:private default-exprs
+  {:clj #"\.(cljc?|edn)$"
+   :cljs #"\.(clj(s|c)|edn)$"})
 
 (def edn-opts
   {:readers {'regex re-pattern
-             'slurp-edn (fn [path]
-                         (edn/read-string (slurp path)))}})
+             'slurp-edn (comp edn/read-string slurp)}})
 
-(defn fetch []
+(defn- ^:dynamic gather
+  "Gather all config files from disk and merge them together, deepest file wins."
+  []
   (->> (conj (fs/parents ".") fs/*cwd*)
        (reverse)
-       (sequence
+       (transduce
          (comp (map #(fs/file % ".conjure.edn"))
                (filter (every-pred fs/file? fs/readable?))
                (map slurp)
-               (map #(edn/read-string edn-opts %))))
-       (apply m/deep-merge)))
+               (map #(edn/read-string edn-opts %)))
+         m/deep-merge)))
+
+(defn- hydrate
+  "Infer some more values from the existing config."
+  [config]
+  (-> config
+      (tl/update (tl/*> (tl/in [:conns]) tl/all-values)
+                 (fn [conn]
+                   (merge {:lang :clj
+                           :expr (get default-exprs (get conn :lang :clj))
+                           :host "127.0.0.1"}
+                          conn)))))
+
+(defn- validate
+  "Ensure the config conforms to the ::config spec, throws."
+  [config]
+  (if (s/valid? ::config config)
+    config
+    (throw (Error. (str "Conjure config failed spec.\n\n"
+                        (expound/expound-str ::config config))))))
+
+(defn fetch
+  "Gather, hydrate and validate the config."
+  []
+  (-> (gather)
+      (hydrate)
+      (validate)))
+
+(comment
+  (time (fetch)))

--- a/src/conjure/config.clj
+++ b/src/conjure/config.clj
@@ -84,8 +84,9 @@
 
 (defn fetch
   "Gather, hydrate and validate the config."
-  [flags]
-  (-> (gather)
-      (hydrate)
-      (toggle flags)
-      (validate)))
+  ([] (fetch {}))
+  ([{:keys [flags] :as _opts}]
+   (-> (gather)
+       (hydrate)
+       (toggle flags)
+       (validate))))

--- a/src/conjure/config.clj
+++ b/src/conjure/config.clj
@@ -1,0 +1,21 @@
+(ns conjure.config
+  "Tools to load all relevant  .conjure.edn files.
+  They're used to manage connection configuration."
+  (:require [clojure.edn :as edn]
+            [medley.core :as m]
+            [me.raynes.fs :as fs]))
+
+(def edn-opts
+  {:readers {'regex re-pattern
+             'slurp-edn (fn [path]
+                         (edn/read-string (slurp path)))}})
+
+(defn fetch []
+  (->> (conj (fs/parents ".") fs/*cwd*)
+       (reverse)
+       (sequence
+         (comp (map #(fs/file % ".conjure.edn"))
+               (filter (every-pred fs/file? fs/readable?))
+               (map slurp)
+               (map #(edn/read-string edn-opts %))))
+       (apply m/deep-merge)))

--- a/src/conjure/main.clj
+++ b/src/conjure/main.clj
@@ -40,12 +40,8 @@
 
 ;; Here we map RPC notifications and requests to their Clojure functions.
 ;; Input strings are parsed as EDN and checked against specs where required.
-
-;; TODO Maybe accept more config here which is merged with config/fetch.
-;; This will allow you to toggle enabled? on some things.
-;; Maybe I accept +foo -bar syntax that will map to enabled? flags.
-(defmethod rpc/handle-notify :up [_]
-  (some-> (config/fetch)
+(defmethod rpc/handle-notify :up [{:keys [params]}]
+  (some-> (config/fetch (first params))
           (get :conns)
           (prepl/sync!)))
 

--- a/src/conjure/main.clj
+++ b/src/conjure/main.clj
@@ -40,6 +40,10 @@
 
 ;; Here we map RPC notifications and requests to their Clojure functions.
 ;; Input strings are parsed as EDN and checked against specs where required.
+
+;; TODO Maybe accept more config here which is merged with config/fetch.
+;; This will allow you to toggle enabled? on some things.
+;; Maybe I accept +foo -bar syntax that will map to enabled? flags.
 (defmethod rpc/handle-notify :up [_]
   (some-> (config/fetch)
           (get :conns)

--- a/src/conjure/main.clj
+++ b/src/conjure/main.clj
@@ -1,11 +1,9 @@
 (ns conjure.main
   "Entry point and registration of RPC handlers."
-  (:require [clojure.edn :as edn]
-            [clojure.spec.alpha :as s]
-            [clojure.string :as str]
-            [expound.alpha :as expound]
+  (:require [clojure.string :as str]
             [taoensso.timbre :as log]
             [taoensso.timbre.appenders.core :as appenders]
+            [conjure.config :as config]
             [conjure.util :as util]
             [conjure.rpc :as rpc]
             [conjure.prepl :as prepl]
@@ -40,27 +38,12 @@
   (log/info "Everything's ready! Let's perform some magic.")
   @(promise))
 
-(defn parse-user-edn
-  "Parses some string as EDN and ensures it conforms to a spec.
-  Returns nil and displays an error if it fails."
-  [spec src]
-  (let [value (edn/read-string {:readers {'regex re-pattern}} src)]
-    (if (s/valid? spec value)
-      value
-      (ui/error (expound/expound-str spec value)))))
-
 ;; Here we map RPC notifications and requests to their Clojure functions.
 ;; Input strings are parsed as EDN and checked against specs where required.
-(defmethod rpc/handle-notify :add [{:keys [params]}]
-  (when-let [new-conn (parse-user-edn ::prepl/new-conn (first params))]
-    (prepl/add! new-conn)))
-
-(defmethod rpc/handle-notify :remove [{:keys [params]}]
-  (when-let [tag (parse-user-edn ::prepl/tag (first params))]
-    (prepl/remove! tag)))
-
-(defmethod rpc/handle-notify :remove-all [_]
-  (prepl/remove-all!))
+(defmethod rpc/handle-notify :up [_]
+  (some-> (config/fetch)
+          (get :conns)
+          (prepl/sync!)))
 
 (defmethod rpc/handle-notify :status [_]
   (prepl/status))

--- a/src/conjure/main.clj
+++ b/src/conjure/main.clj
@@ -41,7 +41,7 @@
 ;; Here we map RPC notifications and requests to their Clojure functions.
 ;; Input strings are parsed as EDN and checked against specs where required.
 (defmethod rpc/handle-notify :up [{:keys [params]}]
-  (some-> (config/fetch (first params))
+  (some-> (config/fetch {:flags (first params)})
           (get :conns)
           (prepl/sync!)))
 

--- a/src/conjure/prepl.clj
+++ b/src/conjure/prepl.clj
@@ -12,7 +12,12 @@
 
 (defonce ^:private conns! (atom {}))
 
-(defn remove!
+(defonce ^:private internal-port
+  (or (some-> (util/env :prepl-server-port)
+              (edn/read-string))
+      (util/free-port)))
+
+(defn- remove!
   "Remove the connection under the given tag. Shuts it down cleanly and blocks
   until it's done."
   [tag]
@@ -33,11 +38,13 @@
         (when-not (nil? (a/<!! read-chan))
           (recur))))))
 
-(defn remove-all! []
+(defn- remove-all!
+  "Iterate over all connections and call remove on them all."
+  []
   (doseq [tag (keys @conns!)]
     (remove! tag)))
 
-(defn connect
+(defn- connect
   "Connect to a prepl and return channels to interact with it. When the eval
   channel closes it cascades through the system and eventually closes the read
   channel. We can use this fact to await the read channel's closure to know
@@ -89,69 +96,77 @@
     {:eval-chan eval-chan
      :read-chan read-chan}))
 
-(defn add!
+(defn- add!
   "Remove any existing connection under :tag then create a new connection."
   [{:keys [tag lang expr host port]}]
 
   (remove! tag)
 
-  (log/info "Adding" tag host port)
-  (ui/info "Adding" tag)
+  (if-not (util/socket? {:host host, :port port})
+    (ui/info "Skipping" tag "- can't connect")
+    (do
+      (log/info "Adding" tag host port)
+      (ui/info "Adding" tag)
 
-  (let [ret-chan (a/chan 32)
-        conn {:tag tag
-              :lang lang
-              :host host
-              :port port
-              :expr expr
-              :chans (merge
-                       {:ret-chan ret-chan}
-                       (connect {:tag tag
-                                 :host host
-                                 :port port}))}
-        prelude (code/prelude-str {:lang lang})]
+      (let [ret-chan (a/chan 32)
+            conn {:tag tag
+                  :lang lang
+                  :host host
+                  :port port
+                  :expr expr
+                  :chans (merge
+                           {:ret-chan ret-chan}
+                           (connect {:tag tag
+                                     :host host
+                                     :port port}))}
+            prelude (code/prelude-str {:lang lang})]
 
-    (swap! conns! assoc tag conn)
+        (swap! conns! assoc tag conn)
 
-    (log/trace "Sending prelude:" (util/sample prelude 20))
-    (a/>!! (get-in conn [:chans :eval-chan]) prelude)
+        (log/trace "Sending prelude:" (util/sample prelude 20))
+        (a/>!! (get-in conn [:chans :eval-chan]) prelude)
 
-    (loop []
-      (if (= ":conjure/ready" (:val (a/<!! (get-in conn [:chans :read-chan]))))
-        (log/trace "Prelude loaded")
-        (recur)))
+        (loop []
+          (if (= ":conjure/ready" (:val (a/<!! (get-in conn [:chans :read-chan]))))
+            (log/trace "Prelude loaded")
+            (recur)))
 
-    (util/thread
-      "read-chan handler"
-      (loop []
-        (when-let [out (a/<!! (get-in conn [:chans :read-chan]))]
-          (log/trace "Read value from" (:tag conn) "-" (update out :form util/sample 20))
-          (let [out (cond-> out
-                      (contains? #{:tap :ret} (:tag out))
-                      (update :val code/parse-code))]
+        (util/thread
+          "read-chan handler"
+          (loop []
+            (when-let [out (a/<!! (get-in conn [:chans :read-chan]))]
+              (log/trace "Read value from" (:tag conn) "-" (update out :form util/sample 20))
+              (let [out (cond-> out
+                          (contains? #{:tap :ret} (:tag out))
+                          (update :val code/parse-code))]
 
-            ;; This is when an error somehow makes it out of the prepl without being caught.
-            ;; It usually means the user is having a bad time, let's at least get
-            ;; something on screen that they can reference in an issue to help fix it.
-            (when (:exception out)
-              (log/error "Uncaught error leaked out of prepl" (:val out))
-              (ui/error "Uncaught error from" (:tag conn) "this might be a bug in Conjure!"
-                        (-> (:val out) clojure.main/ex-triage clojure.main/ex-str))
-              (ui/result {:conn conn
-                          :resp (update out :val (fn [val] [:error val]))}))
+                ;; This is when an error somehow makes it out of the prepl without being caught.
+                ;; It usually means the user is having a bad time, let's at least get
+                ;; something on screen that they can reference in an issue to help fix it.
+                (when (:exception out)
+                  (log/error "Uncaught error leaked out of prepl" (:val out))
+                  (ui/error "Uncaught error from" (:tag conn) "this might be a bug in Conjure!"
+                            (-> (:val out) clojure.main/ex-triage clojure.main/ex-str))
+                  (ui/result {:conn conn
+                              :resp (update out :val (fn [val] [:error val]))}))
 
-            (if (= (:tag out) :ret)
-              (a/>!! ret-chan out)
-              (ui/result {:conn conn, :resp out})))
-          (recur))))))
+                (if (= (:tag out) :ret)
+                  (a/>!! ret-chan out)
+                  (ui/result {:conn conn, :resp out})))
+              (recur))))))))
 
 (defn sync!
   "Disconnect from everything and attempt to connect to every new conn."
   [conns]
   (remove-all!)
-  (doseq [[tag conn] conns
-          :when (:enabled? conn)]
-    (add! (assoc conn :tag tag))))
+
+  (if conns
+    (doseq [[tag conn] conns
+            :when (:enabled? conn)]
+      (add! (assoc conn :tag tag)))
+    (do
+      (ui/info "Warning: No conns configured, connecting to Conjure's own JVM by default.")
+      (add! {:tag :conjure, :port internal-port}))))
 
 (defn conns
   "Without a path it'll return all current connections. With a path it finds
@@ -173,11 +188,6 @@
         conn-strs (for [{:keys [tag host port expr lang]} conns]
                     (str tag " @ " host ":" port " for " (pr-str expr) " (" lang ")"))]
     (ui/info (util/join-lines (into [intro] conn-strs)))))
-
-(defonce internal-port
-  (or (some-> (util/env :prepl-server-port)
-              (edn/read-string))
-      (util/free-port)))
 
 (defn init
   "Initialise the internal prepl."

--- a/src/conjure/prepl.clj
+++ b/src/conjure/prepl.clj
@@ -149,7 +149,8 @@
   "Disconnect from everything and attempt to connect to every new conn."
   [conns]
   (remove-all!)
-  (doseq [[tag conn] conns]
+  (doseq [[tag conn] conns
+          :when (:enabled? conn)]
     (add! (assoc conn :tag tag))))
 
 (defn conns

--- a/src/conjure/ui.clj
+++ b/src/conjure/ui.clj
@@ -5,9 +5,9 @@
             [conjure.util :as util]
             [conjure.result :as result]))
 
+(def ^:private welcome-msg "; conjure/out | Welcome to Conjure!")
 (def ^:private max-log-buffer-length 2000)
 (defonce ^:private log-buffer-name "/tmp/conjure.cljc")
-(def ^:private welcome-msg "; conjure/out | Welcome to Conjure!")
 
 (defn upsert-log
   "Get, create, or update the log window and buffer."

--- a/src/conjure/util.clj
+++ b/src/conjure/util.clj
@@ -7,7 +7,8 @@
             [taoensso.timbre :as log]
             [zprint.core :as zp]
             [camel-snake-kebab.core :as csk]
-            [camel-snake-kebab.extras :as cske]))
+            [camel-snake-kebab.extras :as cske])
+  (:import [java.net Socket]))
 
 (defn join-words [parts]
   (str/join " " parts))
@@ -109,3 +110,10 @@
   (let [socket (java.net.ServerSocket. 0)]
     (.close socket)
     (.getLocalPort socket)))
+
+(defn socket? [{:keys [host port]}]
+  (try
+    (Socket. host port)
+    true
+    (catch Throwable _
+      false)))

--- a/test/conjure/config_test.clj
+++ b/test/conjure/config_test.clj
@@ -1,0 +1,10 @@
+(ns conjure.config-test
+  (:require [clojure.test :as t]
+            [conjure.config :as config]))
+
+(t/deftest fetch
+  (binding [config/gather (constantly {:conns {:foo {:port 5555}}})]
+    (t/is (= (config/fetch) {:conns {:foo {:port 5555
+                                           :host "127.0.0.1"
+                                           :lang :clj
+                                           :expr (#'config/default-exprs :clj)}}}))))

--- a/test/conjure/config_test.clj
+++ b/test/conjure/config_test.clj
@@ -7,4 +7,5 @@
     (t/is (= (config/fetch) {:conns {:foo {:port 5555
                                            :host "127.0.0.1"
                                            :lang :clj
-                                           :expr (#'config/default-exprs :clj)}}}))))
+                                           :expr (#'config/default-exprs :clj)
+                                           :enabled? true}}}))))

--- a/test/conjure/config_test.clj
+++ b/test/conjure/config_test.clj
@@ -3,10 +3,42 @@
             [conjure.config :as config]))
 
 (t/deftest fetch
-  (binding [config/gather (constantly {:conns {:foo {:port 5555}}})]
-    (t/is (= (config/fetch nil)
-             {:conns {:foo {:port 5555
-                            :host "127.0.0.1"
-                            :lang :clj
-                            :expr (#'config/default-exprs :clj)
-                            :enabled? true}}}))))
+  (t/testing "empty"
+    (binding [config/gather (constantly nil)]
+      (t/is (= (config/fetch) nil))))
+
+  (t/testing "basic"
+    (binding [config/gather (constantly {:conns {:foo {:port 5555}}})]
+      (t/is (= (config/fetch)
+               {:conns {:foo {:port 5555
+                              :host "127.0.0.1"
+                              :lang :clj
+                              :expr (#'config/default-exprs :clj)
+                              :enabled? true}}}))))
+
+  (t/testing "flags"
+    (binding [config/gather (constantly {:conns {:foo {:port 5555}
+                                                 :bar {:port 5556, :enabled? false}}})]
+      (t/is (= (config/fetch)
+               {:conns {:foo {:port 5555
+                              :host "127.0.0.1"
+                              :lang :clj
+                              :expr (#'config/default-exprs :clj)
+                              :enabled? true}
+                        :bar {:port 5556
+                              :host "127.0.0.1"
+                              :lang :clj
+                              :expr (#'config/default-exprs :clj)
+                              :enabled? false}}}))
+
+      (t/is (= (config/fetch {:flags "+bar -foo bad $also -notgood"})
+               {:conns {:foo {:port 5555
+                              :host "127.0.0.1"
+                              :lang :clj
+                              :expr (#'config/default-exprs :clj)
+                              :enabled? false}
+                        :bar {:port 5556
+                              :host "127.0.0.1"
+                              :lang :clj
+                              :expr (#'config/default-exprs :clj)
+                              :enabled? true}}})))))

--- a/test/conjure/config_test.clj
+++ b/test/conjure/config_test.clj
@@ -4,8 +4,9 @@
 
 (t/deftest fetch
   (binding [config/gather (constantly {:conns {:foo {:port 5555}}})]
-    (t/is (= (config/fetch) {:conns {:foo {:port 5555
-                                           :host "127.0.0.1"
-                                           :lang :clj
-                                           :expr (#'config/default-exprs :clj)
-                                           :enabled? true}}}))))
+    (t/is (= (config/fetch nil)
+             {:conns {:foo {:port 5555
+                            :host "127.0.0.1"
+                            :lang :clj
+                            :expr (#'config/default-exprs :clj)
+                            :enabled? true}}}))))


### PR DESCRIPTION
Closes #15, basically adds `.conjure.edn` config files and `ConjureUp` instead of `ConjureAdd|Remove|RemoveAll` commands. The new command will try to connect to everything in your config unless `:enabled?` is set to false. You can toggle `:enabled?` with the command with `ConjureUp +jvm -node` which you can bind as you wish.

Connections are now made as you open Neovim, no more opening then connecting! If you open Neovim without any configured connections it'll self prepl and warn you. The theory being if you have config you want to use that, if you don't have config you'll want _some_ sort of temporary eval to try something out.

If my theory is wrong, let me know! The readme has been updated so check that out for more documentation! Let me know how you get on!