### PR TITLE
Optionally fold multiline results

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ You may set these globals with `let` before Conjure loads to configure it's beha
  * `g:conjure_log_size_large = 50` (%) - Size of the log window when explicitly opened by  `ConjureOpenLog`.
  * `g:conjure_log_auto_close = 1` - Enable closing the log window as you enter insert mode in a Clojure buffer.
  * `g:conjure_log_auto_open = "multiline"` - Open the log window after eval, it can be set to `"multiline"`, `"always"` or `"never"`. The default will open it when the eval returns a multiple line result since it doesn't fit into the virtual text display as well.
+ * `g:conjure_fold_results = 0` - Fold multiline results in the log window.
  * `g:conjure_quick_doc_normal_mode = 1` - Enable small doc strings appearing as virtual text in normal mode.
  * `g:conjure_quick_doc_insert_mode = 1` - Enable small doc strings appearing as virtual text in insert mode as you type.
  * `g:conjure_quick_doc_time = 250` (ms) - How long your cursor has to hold before the quick doc will be queried, if enabled.

--- a/plugin/conjure.vim
+++ b/plugin/conjure.vim
@@ -19,6 +19,7 @@ let g:conjure_log_size_small = get(g:, 'conjure_log_size_small', 25) " %
 let g:conjure_log_size_large = get(g:, 'conjure_log_size_large', 50) " %
 let g:conjure_log_auto_close = get(g:, 'conjure_log_auto_close', 1) " 1/0
 let g:conjure_log_auto_open = get(g:, 'conjure_log_auto_open', "multiline") " always/multiline/never
+let g:conjure_fold_results = get(g:, 'conjure_fold_results', 0) " 1/0
 let g:conjure_quick_doc_normal_mode = get(g:, 'conjure_quick_doc_normal_mode', 1) " 1/0
 let g:conjure_quick_doc_insert_mode = get(g:, 'conjure_quick_doc_insert_mode', 1) " 1/0
 let g:conjure_quick_doc_time = get(g:, 'conjure_quick_doc_time', 250) " ms


### PR DESCRIPTION
I really like the way that errors are folded, and I deal with many large results, so I thought allowing folding of multiline results would be useful. Turns out it was quite easy to add.

It's fun to work on a Vim plugin written in Clojure.