### PR TITLE
Improve the wording of the message that prints when conjure exits unexpectedly

### DIFF
--- a/plugin/conjure.vim
+++ b/plugin/conjure.vim
@@ -175,7 +175,7 @@ endfunction
 function! conjure#on_exit(jobid, msg, event) dict
   if a:msg != 0 && a:msg != 143
     echohl ErrorMsg
-    echo "Conjure exited (" . a:msg . "), consider conjure#start()"
+    echo "Conjure exited unexpectedly (" . a:msg . "). Consider restarting it by running ':call conjure#start()'"
     echohl None
 
     let s:jobid = v:null


### PR DESCRIPTION
This error message confused me initially. Now that I have context, I figured there was an opportunity to improve the error message a bit. Feedback welcome!