### PR TITLE
Main help file improvements

### DIFF
--- a/doc/conjure.txt
+++ b/doc/conjure.txt
@@ -179,8 +179,8 @@ CONFIGURATION                                          *conjure-configuration*
 
 As mentioned in |conjure-mappings|, you can use `:ConjureConfig` to display or
 set the different configuration values within Conjure. Here's the full list of
-configuration available in the core plugin. Each language client also has its
-own set of mappings and configuration you can alter.
+options available in the core plugin. Each language client also has its own
+set of mappings and settings you can alter.
 
 As an example, we can change the default prefix from `<localleader>` to `,c`
 with the following command:

--- a/doc/conjure.txt
+++ b/doc/conjure.txt
@@ -179,7 +179,7 @@ CONFIGURATION                                          *conjure-configuration*
 
 As mentioned in |conjure-mappings|, you can use `:ConjureConfig` to display or
 set the different configuration values within Conjure. Here's the full list of
-configuration available in the core plugin. Each language client also has it's
+configuration available in the core plugin. Each language client also has its
 own set of mappings and configuration you can alter.
 
 As an example, we can change the default prefix from `<localleader>` to `,c`


### PR DESCRIPTION
* Fix incorrect "it's".
* Remove repetition of "configuration".

Feel free to drop the stylistic fix; it's just that when I re-read the paragraph, I noticed the multiple "configuration" and thought it could be a quick improvement.