### PR TITLE
Add timer feature for HUD (hide HUD some time after cursor move)

### DIFF
--- a/fnl/conjure/log.fnl
+++ b/fnl/conjure/log.fnl
@@ -8,6 +8,8 @@
             text conjure.text
             editor conjure.editor}})
 
+(var current-timer-id 0)
+
 (defonce- state
   {:hud {:id nil}})
 
@@ -28,6 +30,14 @@
         (nvim.win_close state.hud.id true)
         (set state.hud.id nil)))))
 
+(defn defer-close-hud []
+  (let [my-id current-timer-id]
+    (when state.hud.id
+      (vim.defer_fn (fn []
+                      (when (= my-id current-timer-id)
+                        (close-hud)))
+                    1000))))
+
 (defn- break-lines [buf]
   (let [break-str (break)]
     (->> (nvim.buf_get_lines buf 0 -1 false)
@@ -39,6 +49,7 @@
 
 (defn- display-hud []
   (when config.log.hud.enabled?
+    (set current-timer-id (+ current-timer-id 1))
     (let [buf (upsert-buf)
           cursor-top-right? (and (> (editor.cursor-left) (editor.percent-width 0.5))
                                  (< (editor.cursor-top) (editor.percent-height 0.5)))

--- a/fnl/conjure/mapping.fnl
+++ b/fnl/conjure/mapping.fnl
@@ -80,10 +80,10 @@
     (bridge.viml->lua :conjure.mapping :on-filetype {}))
   (nvim.ex.autocmd
     :CursorMoved :*
-    (bridge.viml->lua :conjure.log :close-hud {}))
+    (bridge.viml->lua :conjure.log :defer-close-hud {}))
   (nvim.ex.autocmd
     :CursorMovedI :*
-    (bridge.viml->lua :conjure.log :close-hud {}))
+    (bridge.viml->lua :conjure.log :defer-close-hud {}))
   (nvim.ex.augroup :END)
   (assoc-initial-config))
 

--- a/lua/conjure/log.lua
+++ b/lua/conjure/log.lua
@@ -28,6 +28,7 @@ local nvim = _2_[6]
 local text = _2_[7]
 local view = _2_[8]
 do local _ = ({nil, _0_0, nil})[2] end
+local current_timer_id = 0
 local state = nil
 do
   local v_23_0_ = (_0_0["aniseed/locals"].state or {hud = {id = nil}})
@@ -86,6 +87,29 @@ do
   _0_0["aniseed/locals"]["close-hud"] = v_23_0_
   close_hud = v_23_0_
 end
+local defer_close_hud = nil
+do
+  local v_23_0_ = nil
+  do
+    local v_23_0_0 = nil
+    local function defer_close_hud0()
+      local my_id = current_timer_id
+      if state.hud.id then
+        local function _3_()
+          if (my_id == current_timer_id) then
+            return close_hud()
+          end
+        end
+        return vim.defer_fn(_3_, 1000)
+      end
+    end
+    v_23_0_0 = defer_close_hud0
+    _0_0["defer-close-hud"] = v_23_0_0
+    v_23_0_ = v_23_0_0
+  end
+  _0_0["aniseed/locals"]["defer-close-hud"] = v_23_0_
+  defer_close_hud = v_23_0_
+end
 local break_lines = nil
 do
   local v_23_0_ = nil
@@ -108,6 +132,7 @@ do
   local v_23_0_ = nil
   local function display_hud0()
     if config.log.hud["enabled?"] then
+      current_timer_id = (current_timer_id + 1)
       local buf = upsert_buf()
       local cursor_top_right_3f = ((editor["cursor-left"]() > editor["percent-width"](0.5)) and (editor["cursor-top"]() < editor["percent-height"](0.5)))
       local last_break = a.last(break_lines(buf))

--- a/lua/conjure/mapping.lua
+++ b/lua/conjure/mapping.lua
@@ -167,8 +167,8 @@ do
       nvim.ex.augroup("conjure_init_filetypes")
       nvim.ex.autocmd_()
       nvim.ex.autocmd("FileType", str.join(",", filetypes), bridge["viml->lua"]("conjure.mapping", "on-filetype", {}))
-      nvim.ex.autocmd("CursorMoved", "*", bridge["viml->lua"]("conjure.log", "close-hud", {}))
-      nvim.ex.autocmd("CursorMovedI", "*", bridge["viml->lua"]("conjure.log", "close-hud", {}))
+      nvim.ex.autocmd("CursorMoved", "*", bridge["viml->lua"]("conjure.log", "defer-close-hud", {}))
+      nvim.ex.autocmd("CursorMovedI", "*", bridge["viml->lua"]("conjure.log", "defer-close-hud", {}))
       nvim.ex.augroup("END")
       return assoc_initial_config()
     end


### PR DESCRIPTION
I found it quite stressful that the HUD would disappear immediately after CursorMove.

This adds a time-out for the HUD to close only 1 second after CursorMove. An additional eval during this period defuses an already running timer.

If this feature is desired I can add an option for the length of the time-out and only activate it when `defer_fn` is available (nightly).