### PR TITLE
Change clojure test to use test-vars

### DIFF
--- a/fnl/conjure/client/clojure/nrepl/action.fnl
+++ b/fnl/conjure/client/clojure/nrepl/action.fnl
@@ -369,9 +369,9 @@
                       {:break? true})
           (require-ns "clojure.test")
           (server.eval
-            {:code (.. "(clojure.test/test-var"
-                       "  (doto (resolve '" test-name ")"
-                       "    (assert \"" test-name " is not a var\")))")
+            {:code (.. "(clojure.test/test-vars"
+                       "  [(doto (resolve '" test-name ")"
+                       "     (assert \"" test-name " is not a var\"))])")
              :context (extract.context)}
             (server.with-all-msgs-fn
               (fn [msgs]

--- a/lua/conjure/client/clojure/nrepl/action.lua
+++ b/lua/conjure/client/clojure/nrepl/action.lua
@@ -774,7 +774,7 @@ do
               return a["run!"](_4_, msgs)
             end
           end
-          return server.eval({code = ("(clojure.test/test-var" .. "  (doto (resolve '" .. test_name .. ")" .. "    (assert \"" .. test_name .. " is not a var\")))"), context = extract.context()}, server["with-all-msgs-fn"](_3_))
+          return server.eval({code = ("(clojure.test/test-vars" .. "  [(doto (resolve '" .. test_name .. ")" .. "     (assert \"" .. test_name .. " is not a var\"))])"), context = extract.context()}, server["with-all-msgs-fn"](_3_))
         end
       end
     end


### PR DESCRIPTION
This switches the Clojure test runner command so it uses `clojure.test/test-vars` instead of `clojure.test/test-var`. Using `test-vars` causes any fixtures to be used in the test run.

If it helps, this is what vim-fireplace does. Here's a PR for that I found https://github.com/tpope/vim-fireplace/pull/231

I don't exactly know how to test this, but the change seemed straightforward enough :man_shrugging: 