### PR TITLE
qualify unqualified nrepl artifact in mvn specs

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,7 @@
  :aliases
  {:nrepl
   {:extra-deps
-   {nrepl {:mvn/version "0.7.0"}}}
+   {nrepl/nrepl {:mvn/version "0.7.0"}}}
 
   :cider
   {:extra-deps


### PR DESCRIPTION
Cleans up deprecated maven artifact warnings.

```
% clj
DEPRECATED: Libs must be qualified, change nrepl => nrepl/nrepl (/Users/penryu/.clojure/deps.edn)
Clojure 1.10.1
user=>
```
Ref: https://insideclojure.org/2020/07/28/clj-exec/