### PR TITLE
Add docs for evaluating Clojure code in markdown

### DIFF
--- a/doc/conjure-client-clojure-nrepl.txt
+++ b/doc/conjure-client-clojure-nrepl.txt
@@ -308,4 +308,9 @@ All configuration can be set as described in |conjure-configuration|.
             machines in large buffers with lots of top level forms.
             Default: `false`
 
+`let g:conjure#filetype_client = {'markdown': 'conjure.client.clojure.nrepl'}`
+            Evaluate Clojure code from within a markdown file.  This needs to 
+            be set before you enter a relevant buffer since the mappings are
+            defined as you enter a buffer.
+
 vim:tw=78:sw=2:ts=2:ft=help:norl:et:listchars=


### PR DESCRIPTION
@Olical you mentioned this setting that allows evaluation of Clojure code from inside of a markdown file on my Reddit thread yesterday.  I thought it might be useful to add it to the docs.  You already cover this filetype_client stuff in [conjure.txt](https://github.com/Olical/conjure/blob/0e63269e176232cdd9f1c20d94dfd3b8ad5702a1/doc/conjure.txt#L196) but having it here might be a bit easier for people to find.   Feel free to  modify this or close it without merging if you disagree.