### PR TITLE
Refactor 'marked-form' into 'at-mark' and re-implement 'marked-form' using it.

### DIFF
--- a/fnl/conjure/eval.fnl
+++ b/fnl/conjure/eval.fnl
@@ -122,9 +122,8 @@
            :range range
            :origin :root-form})))))
 
-(defn marked-form []
-  (let [mark (extract.prompt-char)
-        comment-prefix (client.get :comment-prefix)
+(defn at-mark [mark]
+  (let [comment-prefix (client.get :comment-prefix)
         (ok? err) (pcall #(editor.go-to-mark mark))]
     (if ok?
       (do
@@ -133,6 +132,9 @@
       (log.append [(.. comment-prefix "Couldn't eval form at mark: " mark)
                    (.. comment-prefix err)]
                   {:break? true}))))
+
+(defn marked-form []
+  (at-mark (extract.prompt-char)))
 
 (defn word []
   (let [{: content : range} (extract.word)]

--- a/lua/conjure/client/clojure/nrepl/action.lua
+++ b/lua/conjure/client/clojure/nrepl/action.lua
@@ -137,7 +137,7 @@ do
   local v_0_ = nil
   local function try_ensure_conn0(cb)
     if not server["connected?"]() then
-      return connect_port_file({["silent?"] = true, cb = cb})
+      return connect_port_file({cb = cb, ["silent?"] = true})
     else
       if cb then
         return cb()
@@ -1084,21 +1084,21 @@ do
     local function completions0(opts)
       local function _2_(conn)
         local _3_
-        if enhanced_cljs_completion_3f() then
-          _3_ = "t"
+        if cfg({"completion", "with_context"}) then
+          _3_ = extract_completion_context(opts.prefix)
         else
         _3_ = nil
         end
         local _5_
-        if cfg({"completion", "with_context"}) then
-          _5_ = extract_completion_context(opts.prefix)
+        if enhanced_cljs_completion_3f() then
+          _5_ = "t"
         else
         _5_ = nil
         end
         local function _7_(msgs)
           return opts.cb(a.map(clojure__3evim_completion, a.get(a.last(msgs), "completions")))
         end
-        return server.send({["enhanced-cljs-completion?"] = _3_, ["extra-metadata"] = {"arglists", "doc"}, context = _5_, ns = opts.context, op = "complete", session = conn.session, symbol = opts.prefix}, nrepl["with-all-msgs-fn"](_7_))
+        return server.send({context = _3_, ["enhanced-cljs-completion?"] = _5_, ["extra-metadata"] = {"arglists", "doc"}, ns = opts.context, op = "complete", session = conn.session, symbol = opts.prefix}, nrepl["with-all-msgs-fn"](_7_))
       end
       return server["with-conn-and-op-or-warn"]("complete", _2_, {["else"] = opts.cb, ["silent?"] = true})
     end

--- a/lua/conjure/client/clojure/nrepl/server.lua
+++ b/lua/conjure/client/clojure/nrepl/server.lua
@@ -173,22 +173,22 @@ do
     local v_0_0 = nil
     local function eval0(opts, cb)
       local function _2_(_)
-        local _3_
-        if config["get-in"]({"client", "clojure", "nrepl", "eval", "pretty_print"}) then
-          _3_ = config["get-in"]({"client", "clojure", "nrepl", "eval", "print_function"})
-        else
-        _3_ = nil
-        end
-        local _6_
+        local _4_
         do
-          local _5_0 = a["get-in"](opts, {"range", "start", 2})
-          if _5_0 then
-            _6_ = a.inc(_5_0)
+          local _3_0 = a["get-in"](opts, {"range", "start", 2})
+          if _3_0 then
+            _4_ = a.inc(_3_0)
           else
-            _6_ = _5_0
+            _4_ = _3_0
           end
         end
-        return send({["nrepl.middleware.print/buffer-size"] = config["get-in"]({"client", "clojure", "nrepl", "eval", "print_buffer_size"}), ["nrepl.middleware.print/options"] = {associative = 1, length = (config["get-in"]({"client", "clojure", "nrepl", "eval", "print_options", "length"}) or nil), level = (config["get-in"]({"client", "clojure", "nrepl", "eval", "print_options", "level"}) or nil)}, ["nrepl.middleware.print/print"] = _3_, ["nrepl.middleware.print/quota"] = config["get-in"]({"client", "clojure", "nrepl", "eval", "print_quota"}), code = opts.code, column = _6_, file = opts["file-path"], line = a["get-in"](opts, {"range", "start", 1}), ns = opts.context, op = "eval", session = opts.session}, cb)
+        local _5_
+        if config["get-in"]({"client", "clojure", "nrepl", "eval", "pretty_print"}) then
+          _5_ = config["get-in"]({"client", "clojure", "nrepl", "eval", "print_function"})
+        else
+        _5_ = nil
+        end
+        return send({code = opts.code, column = _4_, file = opts["file-path"], line = a["get-in"](opts, {"range", "start", 1}), ["nrepl.middleware.print/buffer-size"] = config["get-in"]({"client", "clojure", "nrepl", "eval", "print_buffer_size"}), ["nrepl.middleware.print/options"] = {associative = 1, length = (config["get-in"]({"client", "clojure", "nrepl", "eval", "print_options", "length"}) or nil), level = (config["get-in"]({"client", "clojure", "nrepl", "eval", "print_options", "level"}) or nil)}, ["nrepl.middleware.print/print"] = _5_, ["nrepl.middleware.print/quota"] = config["get-in"]({"client", "clojure", "nrepl", "eval", "print_quota"}), ns = opts.context, op = "eval", session = opts.session}, cb)
       end
       return with_conn_or_warn(_2_)
     end
@@ -282,7 +282,7 @@ do
     local v_0_0 = nil
     local function enrich_session_id0(id, cb)
       local function _2_(st)
-        local t = {["pretty-type"] = pretty_session_type(st), id = id, name = uuid.pretty(id), type = st}
+        local t = {id = id, name = uuid.pretty(id), ["pretty-type"] = pretty_session_type(st), type = st}
         local function _3_()
           return (t.name .. " (" .. t["pretty-type"] .. ")")
         end
@@ -475,7 +475,7 @@ do
         assume_or_create_session()
         return eval_preamble(cb)
       end
-      return a.assoc(state.get(), "conn", a["merge!"](nrepl.connect({["default-callback"] = _4_, ["on-error"] = _5_, ["on-failure"] = _6_, ["on-message"] = _7_, ["on-success"] = _8_, host = host, port = port}), {["seen-ns"] = {}}))
+      return a.assoc(state.get(), "conn", a["merge!"](nrepl.connect({["default-callback"] = _4_, host = host, ["on-error"] = _5_, ["on-failure"] = _6_, ["on-message"] = _7_, ["on-success"] = _8_, port = port}), {["seen-ns"] = {}}))
     end
     v_0_0 = connect0
     _0_0["connect"] = v_0_0

--- a/lua/conjure/client/clojure/nrepl/state.lua
+++ b/lua/conjure/client/clojure/nrepl/state.lua
@@ -38,7 +38,7 @@ do
   do
     local v_0_0 = nil
     local function _2_()
-      return {["join-next"] = {key = nil}, conn = nil}
+      return {conn = nil, ["join-next"] = {key = nil}}
     end
     v_0_0 = (_0_0.get or client["new-state"](_2_))
     _0_0["get"] = v_0_0

--- a/lua/conjure/client/fennel/stdio.lua
+++ b/lua/conjure/client/fennel/stdio.lua
@@ -21,7 +21,7 @@ local function _1_(...)
   end
   ok_3f_0_, val_0_ = pcall(_1_)
   if ok_3f_0_ then
-    _0_0["aniseed/local-fns"] = {["require-macros"] = {["conjure.macros"] = true}, require = {a = "conjure.aniseed.core", client = "conjure.client", config = "conjure.config", log = "conjure.log", mapping = "conjure.mapping", nvim = "conjure.aniseed.nvim", stdio = "conjure.remote.stdio", str = "conjure.aniseed.string", text = "conjure.text"}}
+    _0_0["aniseed/local-fns"] = {require = {a = "conjure.aniseed.core", client = "conjure.client", config = "conjure.config", log = "conjure.log", mapping = "conjure.mapping", nvim = "conjure.aniseed.nvim", stdio = "conjure.remote.stdio", str = "conjure.aniseed.string", text = "conjure.text"}, ["require-macros"] = {["conjure.macros"] = true}}
     return val_0_
   else
     return print(val_0_)
@@ -40,7 +40,7 @@ local text = _local_0_[9]
 local _2amodule_2a = _0_0
 local _2amodule_name_2a = "conjure.client.fennel.stdio"
 do local _ = ({nil, _0_0, {{nil}, nil, nil, nil}})[2] end
-config.merge({client = {fennel = {stdio = {["prompt-pattern"] = ">> ", command = "fennel", mapping = {["eval-reload"] = "eF", start = "cs", stop = "cS"}}}}})
+config.merge({client = {fennel = {stdio = {command = "fennel", mapping = {["eval-reload"] = "eF", start = "cs", stop = "cS"}, ["prompt-pattern"] = ">> "}}}})
 local cfg = nil
 do
   local v_0_ = config["get-in-fn"]({"client", "fennel", "stdio"})
@@ -173,7 +173,7 @@ do
       local file_path = nvim.fn.expand("%")
       local module_path = nvim.fn.fnamemodify(file_path, ":.:r")
       log.append({(comment_prefix .. ",reload " .. module_path)}, {["break?"] = true})
-      return eval_str({["file-path"] = file_path, action = "eval", code = (",reload " .. module_path), origin = "reload"})
+      return eval_str({action = "eval", code = (",reload " .. module_path), ["file-path"] = file_path, origin = "reload"})
     end
     v_0_0 = eval_reload0
     _0_0["eval-reload"] = v_0_0
@@ -260,7 +260,7 @@ do
         local function _5_()
           return display_repl_status("started")
         end
-        return a.assoc(state(), "repl", stdio.start({["on-error"] = _2_, ["on-exit"] = _3_, ["on-stray-output"] = _4_, ["on-success"] = _5_, ["prompt-pattern"] = cfg({"prompt-pattern"}), cmd = cfg({"command"})}))
+        return a.assoc(state(), "repl", stdio.start({cmd = cfg({"command"}), ["on-error"] = _2_, ["on-exit"] = _3_, ["on-stray-output"] = _4_, ["on-success"] = _5_, ["prompt-pattern"] = cfg({"prompt-pattern"})}))
       end
     end
     v_0_0 = start0

--- a/lua/conjure/client/janet/netrepl.lua
+++ b/lua/conjure/client/janet/netrepl.lua
@@ -174,7 +174,7 @@ do
       local function _5_()
         return display_conn_status("connected")
       end
-      return a.assoc(state(), "conn", remote.connect({["on-error"] = _3_, ["on-failure"] = _4_, ["on-success"] = _5_, host = host, port = port}))
+      return a.assoc(state(), "conn", remote.connect({host = host, ["on-error"] = _3_, ["on-failure"] = _4_, ["on-success"] = _5_, port = port}))
     end
     v_0_0 = connect0
     _0_0["connect"] = v_0_0

--- a/lua/conjure/client/racket/stdio.lua
+++ b/lua/conjure/client/racket/stdio.lua
@@ -21,7 +21,7 @@ local function _1_(...)
   end
   ok_3f_0_, val_0_ = pcall(_1_)
   if ok_3f_0_ then
-    _0_0["aniseed/local-fns"] = {["require-macros"] = {["conjure.macros"] = true}, require = {a = "conjure.aniseed.core", client = "conjure.client", config = "conjure.config", log = "conjure.log", mapping = "conjure.mapping", nvim = "conjure.aniseed.nvim", stdio = "conjure.remote.stdio", str = "conjure.aniseed.string", text = "conjure.text"}}
+    _0_0["aniseed/local-fns"] = {require = {a = "conjure.aniseed.core", client = "conjure.client", config = "conjure.config", log = "conjure.log", mapping = "conjure.mapping", nvim = "conjure.aniseed.nvim", stdio = "conjure.remote.stdio", str = "conjure.aniseed.string", text = "conjure.text"}, ["require-macros"] = {["conjure.macros"] = true}}
     return val_0_
   else
     return print(val_0_)
@@ -40,7 +40,7 @@ local text = _local_0_[9]
 local _2amodule_2a = _0_0
 local _2amodule_name_2a = "conjure.client.racket.stdio"
 do local _ = ({nil, _0_0, {{nil}, nil, nil, nil}})[2] end
-config.merge({client = {racket = {stdio = {["prompt-pattern"] = "\n?[\"%w%-./_]*> ", command = "racket", mapping = {start = "cs", stop = "cS"}}}}})
+config.merge({client = {racket = {stdio = {command = "racket", mapping = {start = "cs", stop = "cS"}, ["prompt-pattern"] = "\n?[\"%w%-./_]*> "}}}})
 local cfg = nil
 do
   local v_0_ = config["get-in-fn"]({"client", "racket", "stdio"})
@@ -286,7 +286,7 @@ do
           display_repl_status("started")
           return enter()
         end
-        return a.assoc(state(), "repl", stdio.start({["on-error"] = _2_, ["on-exit"] = _3_, ["on-stray-output"] = _4_, ["on-success"] = _5_, ["prompt-pattern"] = cfg({"prompt-pattern"}), cmd = cfg({"command"})}))
+        return a.assoc(state(), "repl", stdio.start({cmd = cfg({"command"}), ["on-error"] = _2_, ["on-exit"] = _3_, ["on-stray-output"] = _4_, ["on-success"] = _5_, ["prompt-pattern"] = cfg({"prompt-pattern"})}))
       end
     end
     v_0_0 = start0

--- a/lua/conjure/eval.lua
+++ b/lua/conjure/eval.lua
@@ -98,7 +98,7 @@ do
     local v_0_0 = nil
     local function file0()
       event.emit("eval", "file")
-      local opts = {["file-path"] = fs["resolve-relative"](extract["file-path"]()), action = "eval", origin = "file"}
+      local opts = {action = "eval", ["file-path"] = fs["resolve-relative"](extract["file-path"]()), origin = "file"}
       opts.preview = preview(opts)
       display_request(opts)
       return client.call("eval-file", with_last_result_hook(opts))
@@ -126,7 +126,7 @@ do
   local v_0_ = nil
   local function client_exec_fn0(action, f_name, base_opts)
     local function _2_(opts)
-      local opts0 = a.merge(opts, base_opts, {["file-path"] = extract["file-path"](), action = action})
+      local opts0 = a.merge(opts, base_opts, {action = action, ["file-path"] = extract["file-path"]()})
       assoc_context(opts0)
       opts0.preview = preview(opts0)
       if not opts0["passive?"] then
@@ -234,7 +234,7 @@ do
           buffer["replace-range"](buf, range, result)
           return editor["go-to"](win, a["get-in"](range, {"start", 1}), a.inc(a["get-in"](range, {"start", 2})))
         end
-        eval_str({["on-result"] = _2_, ["suppress-hud?"] = true, code = content, origin = "replace-form", range = range})
+        eval_str({code = content, ["on-result"] = _2_, origin = "replace-form", range = range, ["suppress-hud?"] = true})
         return form
       end
     end
@@ -266,13 +266,12 @@ do
   _0_0["aniseed/locals"]["root-form"] = v_0_
   root_form = v_0_
 end
-local marked_form = nil
+local at_mark = nil
 do
   local v_0_ = nil
   do
     local v_0_0 = nil
-    local function marked_form0()
-      local mark = extract["prompt-char"]()
+    local function at_mark0(mark)
       local comment_prefix = client.get("comment-prefix")
       local ok_3f, err = nil, nil
       local function _2_()
@@ -285,6 +284,21 @@ do
       else
         return log.append({(comment_prefix .. "Couldn't eval form at mark: " .. mark), (comment_prefix .. err)}, {["break?"] = true})
       end
+    end
+    v_0_0 = at_mark0
+    _0_0["at-mark"] = v_0_0
+    v_0_ = v_0_0
+  end
+  _0_0["aniseed/locals"]["at-mark"] = v_0_
+  at_mark = v_0_
+end
+local marked_form = nil
+do
+  local v_0_ = nil
+  do
+    local v_0_0 = nil
+    local function marked_form0()
+      return at_mark(extract["prompt-char"]())
     end
     v_0_0 = marked_form0
     _0_0["marked-form"] = v_0_0
@@ -410,7 +424,7 @@ do
   do
     local v_0_0 = nil
     local function selection0(kind)
-      local _let_0_ = extract.selection({["visual?"] = not kind, kind = (kind or nvim.fn.visualmode())})
+      local _let_0_ = extract.selection({kind = (kind or nvim.fn.visualmode()), ["visual?"] = not kind})
       local content = _let_0_["content"]
       local range0 = _let_0_["range"]
       return eval_str({code = content, origin = "selection", range = range0})

--- a/lua/conjure/extract.lua
+++ b/lua/conjure/extract.lua
@@ -335,7 +335,7 @@ do
       elseif (kind == "line") then
         nu.normal("'[V']y")
       elseif (kind == "block") then
-        nu.normal("`[\22`]y")
+        nu.normal("`[`]y")
       else
         nu.normal("`[v`]y")
       end

--- a/lua/conjure/net.lua
+++ b/lua/conjure/net.lua
@@ -21,7 +21,7 @@ local function _1_(...)
   end
   ok_3f_0_, val_0_ = pcall(_1_)
   if ok_3f_0_ then
-    _0_0["aniseed/local-fns"] = {["require-macros"] = {["conjure.macros"] = true}, require = {a = "conjure.aniseed.core", bridge = "conjure.bridge", nvim = "conjure.aniseed.nvim"}}
+    _0_0["aniseed/local-fns"] = {require = {a = "conjure.aniseed.core", bridge = "conjure.bridge", nvim = "conjure.aniseed.nvim"}, ["require-macros"] = {["conjure.macros"] = true}}
     return val_0_
   else
     return print(val_0_)
@@ -98,7 +98,7 @@ do
       local function _3_()
         return destroy_sock(sock)
       end
-      return {["resolved-host"] = resolved_host, destroy = _3_, host = host, port = port, sock = sock}
+      return {destroy = _3_, host = host, port = port, ["resolved-host"] = resolved_host, sock = sock}
     end
     v_0_0 = connect0
     _0_0["connect"] = v_0_0

--- a/lua/conjure/remote/nrepl.lua
+++ b/lua/conjure/remote/nrepl.lua
@@ -67,7 +67,7 @@ do
   do
     local v_0_0 = nil
     local function connect0(opts)
-      local state = {["awaiting-process?"] = false, ["message-queue"] = {}, bc = bencode.new(), msgs = {}}
+      local state = {["awaiting-process?"] = false, bc = bencode.new(), ["message-queue"] = {}, msgs = {}}
       local conn = {session = nil}
       local function enrich_status(msg)
         local ks = a.get(msg, "status")
@@ -88,7 +88,7 @@ do
         log.dbg("send", msg)
         local function _3_()
         end
-        a["assoc-in"](state, {"msgs", msg_id}, {["sent-at"] = os.time(), cb = (cb or _3_), msg = msg})
+        a["assoc-in"](state, {"msgs", msg_id}, {cb = (cb or _3_), msg = msg, ["sent-at"] = os.time()})
         do end (conn.sock):write(bencode.encode(msg))
         return nil
       end

--- a/lua/conjure/text.lua
+++ b/lua/conjure/text.lua
@@ -178,7 +178,7 @@ do
   do
     local v_0_0 = nil
     local function strip_ansi_escape_sequences0(s)
-      return string.gsub(string.gsub(string.gsub(string.gsub(string.gsub(s, "\27%[%d+;%d+;%d+;%d+;%d+m", ""), "\27%[%d+;%d+;%d+;%d+m", ""), "\27%[%d+;%d+;%d+m", ""), "\27%[%d+;%d+m", ""), "\27%[%d+m", "")
+      return string.gsub(string.gsub(string.gsub(string.gsub(string.gsub(s, "x1b%[%d+;%d+;%d+;%d+;%d+m", ""), "x1b%[%d+;%d+;%d+;%d+m", ""), "x1b%[%d+;%d+;%d+m", ""), "x1b%[%d+;%d+m", ""), "x1b%[%d+m", "")
     end
     v_0_0 = strip_ansi_escape_sequences0
     _0_0["strip-ansi-escape-sequences"] = v_0_0


### PR DESCRIPTION
I was trying to use `eval.marked-form` in a binding and couldn't hard code a mark name, so this happened.

I wasn't super sure on the names, but I didn't want to break backwards compatibility on `marked-form` so I left it the same.

One note, I tried running `make compile` as described in the contributing docs, but it changes a lot of things that don't seem to be related to my change. Did I mess something up? I will include them as a separate commit so it is easier to review, and if they do look ok then I can rebase them up before this gets merged.