### PR TITLE
Prevent loading readline config on fennel stdio

### DIFF
--- a/doc/conjure-client-fennel-stdio.txt
+++ b/doc/conjure-client-fennel-stdio.txt
@@ -6,7 +6,6 @@ CONTENTS                                *conjure-client-fennel-stdio-contents*
     1. Introduction ........ |conjure-client-fennel-stdio-introduction|
     2. Mappings ................ |conjure-client-fennel-stdio-mappings|
     3. Configuration ...... |conjure-client-fennel-stdio-configuration|
-    4. Bugs ........................ |conjure-client-fennel-stdio-bugs|
 
 ==============================================================================
 INTRODUCTION                        *conjure-client-fennel-stdio-introduction*
@@ -68,17 +67,5 @@ All configuration can be set as described in |conjure-configuration|.
             Command used to start the Fennel REPL, you can modify this to add
             arguments or change the command entirely.
             Default: `"fennel"`
-
-==============================================================================
-BUGS                                        *conjure-client-fennel-stdio-bugs*
-
-If you find that after enabling the fennel stdio client, Neovim becomes
-unresponsive and/or generally broken when opening .fnl files, the fennel
-readline integration is probably breaking things. In this case, you should
-uninstall the lua readline module, remove it from your `LUA_PATH` environment
-variable or use an alternate lua interpreter by setting the command variable.
-For example, with this option:
->
-  let g:conjure#client#fennel#stdio#command = "fennel --lua /usr/bin/lua5.4"
 
 vim:tw=78:sw=2:ts=2:ft=help:norl:et:listchars=

--- a/fnl/conjure/client/fennel/stdio.fnl
+++ b/fnl/conjure/client/fennel/stdio.fnl
@@ -99,6 +99,7 @@
       (stdio.start
         {:prompt-pattern (cfg [:prompt-pattern])
          :cmd (cfg [:command])
+         :env ["INPUTRC=/dev/null"]
 
          :on-success
          (fn []

--- a/fnl/conjure/remote/stdio.fnl
+++ b/fnl/conjure/remote/stdio.fnl
@@ -98,7 +98,8 @@
 
     (let [{: cmd : args} (parse-cmd opts.cmd)
           (handle pid) (uv.spawn cmd {:stdio [stdin stdout stderr]
-                                      :args args}
+                                      :args args
+                                      :env opts.env}
                                  (client.schedule-wrap on-exit))]
       (stdout:read_start (client.schedule-wrap on-stdout))
       (stderr:read_start (client.schedule-wrap on-stderr))


### PR DESCRIPTION
This fixes #166. The bug was caused by readline inserting control
characters into the fennel repl. By skipping the user readline config,
they are prevented from modifying the repl in arbitrary dangerous ways.
This is fine, because the readline editing facilities are completely
useless in the context of conjure, since we rely solely on neovim's
editing capabilities.

Note: The user is still able to configure the lua readline library
through their ~/.fennelrc file, for example, to persist their history.