### PR TITLE
Prevent loading readline config on fennel stdio

### DIFF
--- a/doc/conjure-client-fennel-stdio.txt
+++ b/doc/conjure-client-fennel-stdio.txt
@@ -6,7 +6,6 @@ CONTENTS                                *conjure-client-fennel-stdio-contents*
     1. Introduction ........ |conjure-client-fennel-stdio-introduction|
     2. Mappings ................ |conjure-client-fennel-stdio-mappings|
     3. Configuration ...... |conjure-client-fennel-stdio-configuration|
-    4. Bugs ........................ |conjure-client-fennel-stdio-bugs|
 
 ==============================================================================
 INTRODUCTION                        *conjure-client-fennel-stdio-introduction*
@@ -68,17 +67,5 @@ All configuration can be set as described in |conjure-configuration|.
             Command used to start the Fennel REPL, you can modify this to add
             arguments or change the command entirely.
             Default: `"fennel"`
-
-==============================================================================
-BUGS                                        *conjure-client-fennel-stdio-bugs*
-
-If you find that after enabling the fennel stdio client, Neovim becomes
-unresponsive and/or generally broken when opening .fnl files, the fennel
-readline integration is probably breaking things. In this case, you should
-uninstall the lua readline module, remove it from your `LUA_PATH` environment
-variable or use an alternate lua interpreter by setting the command variable.
-For example, with this option:
->
-  let g:conjure#client#fennel#stdio#command = "fennel --lua /usr/bin/lua5.4"
 
 vim:tw=78:sw=2:ts=2:ft=help:norl:et:listchars=

--- a/fnl/conjure/client/fennel/stdio.fnl
+++ b/fnl/conjure/client/fennel/stdio.fnl
@@ -99,6 +99,7 @@
       (stdio.start
         {:prompt-pattern (cfg [:prompt-pattern])
          :cmd (cfg [:command])
+         :env ["INPUTRC=/dev/null"]
 
          :on-success
          (fn []

--- a/fnl/conjure/remote/stdio.fnl
+++ b/fnl/conjure/remote/stdio.fnl
@@ -98,7 +98,8 @@
 
     (let [{: cmd : args} (parse-cmd opts.cmd)
           (handle pid) (uv.spawn cmd {:stdio [stdin stdout stderr]
-                                      :args args}
+                                      :args args
+                                      :env opts.env}
                                  (client.schedule-wrap on-exit))]
       (stdout:read_start (client.schedule-wrap on-stdout))
       (stderr:read_start (client.schedule-wrap on-stderr))

--- a/lua/conjure/client/fennel/stdio.lua
+++ b/lua/conjure/client/fennel/stdio.lua
@@ -275,7 +275,7 @@ do
         local function _5_()
           return display_repl_status("started")
         end
-        return a.assoc(state(), "repl", stdio.start({["on-error"] = _2_, ["on-exit"] = _3_, ["on-stray-output"] = _4_, ["on-success"] = _5_, ["prompt-pattern"] = cfg({"prompt-pattern"}), cmd = cfg({"command"})}))
+        return a.assoc(state(), "repl", stdio.start({["on-error"] = _2_, ["on-exit"] = _3_, ["on-stray-output"] = _4_, ["on-success"] = _5_, ["prompt-pattern"] = cfg({"prompt-pattern"}), cmd = cfg({"command"}), env = {"INPUTRC=/dev/null"}}))
       end
     end
     v_0_0 = start0

--- a/lua/conjure/remote/stdio.lua
+++ b/lua/conjure/remote/stdio.lua
@@ -165,7 +165,7 @@ do
       local _let_0_ = parse_cmd(opts.cmd)
       local args = _let_0_["args"]
       local cmd = _let_0_["cmd"]
-      local handle, pid = uv.spawn(cmd, {args = args, stdio = {stdin, stdout, stderr}}, client["schedule-wrap"](on_exit))
+      local handle, pid = uv.spawn(cmd, {args = args, env = opts.env, stdio = {stdin, stdout, stderr}}, client["schedule-wrap"](on_exit))
       stdout:read_start(client["schedule-wrap"](on_stdout))
       stderr:read_start(client["schedule-wrap"](on_stderr))
       local function _2_()


### PR DESCRIPTION
This fixes #166. The bug was caused by readline inserting control
characters into the fennel repl. By skipping the user readline config,
they are prevented from modifying the repl in arbitrary dangerous ways.
This is fine, because the readline editing facilities are completely
useless in the context of conjure, since we rely solely on neovim's
editing capabilities.

Note: The user is still able to configure the lua readline library
through their ~/.fennelrc file, for example, to persist their history.