### PR TITLE
remote.socket: Use strip-ansi-escape-sequences instead of gsub

### DIFF
--- a/fnl/conjure/remote/socket.fnl
+++ b/fnl/conjure/remote/socket.fnl
@@ -3,6 +3,7 @@
             nvim conjure.aniseed.nvim
             str conjure.aniseed.string
             client conjure.client
+            text conjure.text
             log conjure.log}})
 
 (def- uv vim.loop)
@@ -10,7 +11,7 @@
 (defn- strip-unprintable [s]
   (string.gsub
     (string.gsub
-      (string.gsub s "%c%[[%d%;]+m" "")
+      (text.strip-ansi-escape-sequences s)
       "\1" "")
     "\2" ""))
 


### PR DESCRIPTION
Sorry, I'd make a classic "forgot to push" mistake with #178.  Here is the missing de-duplication!