### PR TITLE
Implement highlight evaluation

### DIFF
--- a/fnl/conjure/config.fnl
+++ b/fnl/conjure/config.fnl
@@ -98,6 +98,11 @@
    {:omnifunc :ConjureOmnifunc
     :fallback :syntaxcomplete#Complete}
 
+   :highlight
+   {:enabled false
+    :group "IncSearch"
+    :timeout 500}
+
    :log
    {:wrap false
     :hud {:width 0.42


### PR DESCRIPTION
This implements highlights for evaluation as described in #113.  I did an almost direct conversion from @davidsierradz's Lua code to Fennel.

To configure (hopefully self-explanatory):
```
let g:conjure#highlight#enabled = 1
let g:conjure#highlight#timeout = 500
let g:conjure#highlight#group = "IncSearch"
```
These are the defaults, except for `enabled` which defaults to false.

Unfortunately, this requires a very recent NeoVim to work: more than 0.4.4, which is the latest release version at the time of writing.  I chose to make it silently fail on older versions.

I'm not sure if I called the Vim API functions in the correct idiomatic way.  I struggled to use `nvim` (i.e. `conjure.aniseed.nvim`) - it seemed to choke on the function name containing a dot (`highlight.range`).  Perhaps I didn't try hard enough.

**Question/rationale for defaulting to disabled:** Is there a way to set an option to `false` with normal `.vimrc`?  Setting a `g:conjure#something` variable to `0` in fact enables the option.  `debug` seems to work the same way, so I didn't do anything extra to make the behaviour more logical (to me).
