### PR TITLE
Add help tags for commands and configuration options

### DIFF
--- a/doc/conjure-client-clojure-nrepl.txt
+++ b/doc/conjure-client-clojure-nrepl.txt
@@ -45,6 +45,7 @@ options relevant to these mappings.
                          `:ConjureConnect 5678`
                          `:ConjureConnect`
 
+                                                        *:ConjureShadowSelect*
 :ConjureShadowSelect [build]
                          Select a shadow-cljs build for evaluation within this
                          session. Calls through to the
@@ -52,6 +53,7 @@ options relevant to these mappings.
                          `:ConjureShadowSelect my-app`
                          https://github.com/thheller/shadow-cljs
 
+                                                          *:ConjurePiggieback*
 :ConjurePiggieback [code]
                          Piggieback your current session on top of a
                          ClojureScript evaluation environment. You must
@@ -63,9 +65,11 @@ options relevant to these mappings.
                          Calls through to `cider.piggieback/cljs-repl`.
                          https://github.com/nrepl/piggieback
 
+                                                        *:ConjureOutSubscribe*
 :ConjureOutSubscribe     Change `#'*out*` so that it also prints to active
                          sessions, even outside an eval scope.
 
+                                                      *:ConjureOutUnsubscribe*
 :ConjureOutUnsubscribe   Change `#'*out*` so that it no longer prints to
                          active sessions outside an eval scope.
 
@@ -127,11 +131,13 @@ CONFIGURATION                     *conjure-client-clojure-nrepl-configuration*
 
 All configuration can be set as described in |conjure-configuration|.
 
+                      *g:conjure#client#clojure#nrepl#connection#default_host*
 `g:conjure#client#clojure#nrepl#connection#default_host`
             When connecting to port files or via `:ConjureConnect` this is the
             default host to use.
             Default: `"localhost"`
 
+                        *g:conjure#client#clojure#nrepl#connection#port_files*
 `g:conjure#client#clojure#nrepl#connection#port_files`
             List of file paths to check when starting up or hitting
             `<localleader>cf` (by default). They're checked in order, the
@@ -143,6 +149,7 @@ All configuration can be set as described in |conjure-configuration|.
             file in there to always have a default port to attempt.
             Default: `[".nrepl-port" ".shadow-cljs/nrepl.port"]`
 
+                 *g:conjure#client#clojure#nrepl#connection#auto_repl#enabled*
 `g:conjure#client#clojure#nrepl#connection#auto_repl#enabled`
             Start the "auto-repl" process when Conjure tries to connect to an
             existing nREPL and can't find any candidates. Useful for getting
@@ -150,6 +157,7 @@ All configuration can be set as described in |conjure-configuration|.
             manage external processes.
             Default: `true`
 
+                     *g:conjure#client#clojure#nrepl#connection#auto_repl#cmd*
 `g:conjure#client#clojure#nrepl#connection#auto_repl#cmd`
             The command to execute when starting the auto-repl. By default we
             start a Babashka nREPL server on port `8794` but only if you have
@@ -161,6 +169,8 @@ All configuration can be set as described in |conjure-configuration|.
             your chosen port number.
             Default: `"bb nrepl-server localhost:8794"`
 
+               *g:conjure#client#clojure#nrepl#connection#auto_repl#port_file*
+                    *g:conjure#client#clojure#nrepl#connection#auto_repl#port*
 `g:conjure#client#clojure#nrepl#connection#auto_repl#port_file`
 `g:conjure#client#clojure#nrepl#connection#auto_repl#port`
             When both set, the port will be written to the port file when the
@@ -168,33 +178,39 @@ All configuration can be set as described in |conjure-configuration|.
             contained within the file is still the same as the auto-repl port.
             Default: `".nrepl-port"`, `"8794"`
 
+                            *g:conjure#client#clojure#nrepl#eval#pretty_print*
 `g:conjure#client#clojure#nrepl#eval#pretty_print`
             Should results be pretty printed by the nREPL server.
             Relies on `clojure.pprint/write`.
             Default: `true`
 
+                                 *g:conjure#client#clojure#nrepl#eval#raw_out*
 `g:conjure#client#clojure#nrepl#eval#raw_out`
             Don't prefix stdout lines with `; (out)`, useful if you print data a
             lot and don't want to have to strip the comment prefixes each
             time.
             Default: `false`
 
+                             *g:conjure#client#clojure#nrepl#eval#print_quota*
 `g:conjure#client#clojure#nrepl#eval#print_quota`
             A hard limit on the number of bytes printed for each value.
             Default: `nil`
 
+                       *g:conjure#client#clojure#nrepl#eval#print_buffer_size*
 `g:conjure#client#clojure#nrepl#eval#print_buffer_size`
             The size of the buffer to use when streaming results. Defaults to
             1024 within nREPL itself. You can increase this value to reduce
             the amount of messages large results are split up into by nREPL.
             Default: `nil`
 
+                          *g:conjure#client#clojure#nrepl#eval#print_function*
 `g:conjure#client#clojure#nrepl#eval#print_function`
             A fully-qualified symbol naming a var whose function to use for
             printing.
             Must point to a function with signature [value writer options].
             Default: `"conjure.internal/pprint"`
 
+                            *g:conjure#client#clojure#nrepl#eval#auto_require*
 `g:conjure#client#clojure#nrepl#eval#auto_require`
             Automatically require the namespace of any new buffer you open, or
             your current buffer after connection. This ensures buffers you're
@@ -202,43 +218,51 @@ All configuration can be set as described in |conjure-configuration|.
             if you have side effects at the top level of your namespace.
             Default: `true`
 
+                     *g:conjure#client#clojure#nrepl#eval#print_options#level*
 `g:conjure#client#clojure#nrepl#eval#print_options#level`
             Elide data in the output that surpasses this level of depth with
             the pretty printer. Set it to `false` to disable this limit.
             Default: `50`
 
+                    *g:conjure#client#clojure#nrepl#eval#print_options#length*
 `g:conjure#client#clojure#nrepl#eval#print_options#length`
             Elide data in the output that surpasses this many items, great for
             preventing infinite lazy sequences from melting your CPU. Set it
             to `false` to disable this limit.
             Default: `500`
 
+                       *g:conjure#client#clojure#nrepl#interrupt#sample_limit*
 `g:conjure#client#clojure#nrepl#interrupt#sample_limit`
             How many characters to show of the code you just interrupted as a
             preview in the log. The value is based on a percentage of the
             width of the full editor.
             Default: `0.3`
 
+                                *g:conjure#client#clojure#nrepl#refresh#after*
 `g:conjure#client#clojure#nrepl#refresh#after`
             The namespace-qualified name of a zero-arity function to call
             after reloading.
             Default: `nil`
 
+                               *g:conjure#client#clojure#nrepl#refresh#before*
 `g:conjure#client#clojure#nrepl#refresh#before`
             The namespace-qualified name of a zero-arity function to call
             before reloading.
             Default: `nil`
 
+                                 *g:conjure#client#clojure#nrepl#refresh#dirs*
 `g:conjure#client#clojure#nrepl#refresh#dirs`
             List of directories to scan. If no directories given, defaults to
             all directories on the classpath.
             Default: `nil`
 
+                      *g:conjure#client#clojure#nrepl#test#current_form_names*
 `g:conjure#client#clojure#nrepl#test#current_form_names`
             List of keywords that are used to decide if the
             current root form is a test that should be ran.
             Default: `["deftest"]`
 
+                                  *g:conjure#client#clojure#nrepl#test#runner*
 `g:conjure#client#clojure#nrepl#test#runner`
             Test runner to use for the various test mappings. The following
             are supported:
@@ -247,6 +271,7 @@ All configuration can be set as described in |conjure-configuration|.
             More can be added through contributions where required.
             Default: `"clojure"`
 
+                             *g:conjure#client#clojure#nrepl#test#call_suffix*
 `g:conjure#client#clojure#nrepl#test#call_suffix`
             Overrides the string appended to the end of the test runner
             function calls. This isn't used by default for the `clojure` test
@@ -263,104 +288,129 @@ All configuration can be set as described in |conjure-configuration|.
 
             Default: `nil`
 
+                           *g:conjure#client#clojure#nrepl#mapping#disconnect*
 `g:conjure#client#clojure#nrepl#mapping#disconnect`
             Disconnect from the current nREPL server.
             Default: `cd`
 
+                    *g:conjure#client#clojure#nrepl#mapping#connect_port_file*
 `g:conjure#client#clojure#nrepl#mapping#connect_port_file`
             Connect to a local server via a port file.
             Default: `cf`
 
+                            *g:conjure#client#clojure#nrepl#mapping#interrupt*
 `g:conjure#client#clojure#nrepl#mapping#interrupt`
             Interrupt an evaluation.
             Default: `ei`
 
+                       *g:conjure#client#clojure#nrepl#mapping#last_exception*
 `g:conjure#client#clojure#nrepl#mapping#last_exception`
             View the last exception.
             Default: `ve`
 
+                             *g:conjure#client#clojure#nrepl#mapping#result_1*
 `g:conjure#client#clojure#nrepl#mapping#result_1`
             View the most recent result.
             Default: `v1`
 
+                             *g:conjure#client#clojure#nrepl#mapping#result_2*
 `g:conjure#client#clojure#nrepl#mapping#result_2`
             View the 2nd most recent result.
             Default: `v2`
 
+                             *g:conjure#client#clojure#nrepl#mapping#result_3*
 `g:conjure#client#clojure#nrepl#mapping#result_3`
             View the 3rd most recent result.
             Default: `v3`
 
+                          *g:conjure#client#clojure#nrepl#mapping#view_source*
 `g:conjure#client#clojure#nrepl#mapping#view_source`
             View the source of the symbol under the cursor.
             Default: `vs`
 
+                        *g:conjure#client#clojure#nrepl#mapping#session_clone*
 `g:conjure#client#clojure#nrepl#mapping#session_clone`
             Clone the current session.
             Default: `sc`
 
+                        *g:conjure#client#clojure#nrepl#mapping#session_fresh*
 `g:conjure#client#clojure#nrepl#mapping#session_fresh`
             Create a fresh session.
             Default: `sf`
 
+                        *g:conjure#client#clojure#nrepl#mapping#session_close*
 `g:conjure#client#clojure#nrepl#mapping#session_close`
             Close the current session.
             Default: `sq`
 
+                    *g:conjure#client#clojure#nrepl#mapping#session_close_all*
 `g:conjure#client#clojure#nrepl#mapping#session_close_all`
             Close all sessions.
             Default: `sQ`
 
+                         *g:conjure#client#clojure#nrepl#mapping#session_list*
 `g:conjure#client#clojure#nrepl#mapping#session_list`
             List all current sessions.
             Default: `sl`
 
+                         *g:conjure#client#clojure#nrepl#mapping#session_next*
 `g:conjure#client#clojure#nrepl#mapping#session_next`
             Assume the next session in the list.
             Default: `sn`
 
+                         *g:conjure#client#clojure#nrepl#mapping#session_prev*
 `g:conjure#client#clojure#nrepl#mapping#session_prev`
             Assume the previous session in the list.
             Default: `sp`
 
+                       *g:conjure#client#clojure#nrepl#mapping#session_select*
 `g:conjure#client#clojure#nrepl#mapping#session_select`
             Select a session from the list with an interactive prompt.
             Default: `ss`
 
+                        *g:conjure#client#clojure#nrepl#mapping#run_all_tests*
 `g:conjure#client#clojure#nrepl#mapping#run_all_tests`
             Run all loaded tests.
             Default: `ta`
 
+                 *g:conjure#client#clojure#nrepl#mapping#run_current_ns_tests*
 `g:conjure#client#clojure#nrepl#mapping#run_current_ns_tests`
             Run all tests within the current namespace.
             Default: `tn`
 
+               *g:conjure#client#clojure#nrepl#mapping#run_alternate_ns_tests*
 `g:conjure#client#clojure#nrepl#mapping#run_alternate_ns_tests`
             Run all tests within the alternate namespace. Executing in
             `foo.bar` would test `foo.bar-test` and the other way around.
             Default: `tN`
 
+                     *g:conjure#client#clojure#nrepl#mapping#run_current_test*
 `g:conjure#client#clojure#nrepl#mapping#run_current_test`
             Run the test under the cursor, can be used from anywhere within
             the form.
             Default: `tc`
 
+                      *g:conjure#client#clojure#nrepl#mapping#refresh_changed*
 `g:conjure#client#clojure#nrepl#mapping#refresh_changed`
             Refresh changed namespaces.
             Default: `rr`
 
+                          *g:conjure#client#clojure#nrepl#mapping#refresh_all*
 `g:conjure#client#clojure#nrepl#mapping#refresh_all`
             Refresh all namespaces.
             Default: `ra`
 
+                        *g:conjure#client#clojure#nrepl#mapping#refresh_clear*
 `g:conjure#client#clojure#nrepl#mapping#refresh_clear`
             Clear the namespace refresh cache.
             Default: `rc`
 
+                 *g:conjure#client#clojure#nrepl#completion#cljs#use_suitable*
 `g:conjure#client#clojure#nrepl#completion#cljs#use_suitable`
             Use `clj-suitable` to improve cljs completion.
             Default: `true`
 
+                      *g:conjure#client#clojure#nrepl#completion#with_context*
 `g:conjure#client#clojure#nrepl#completion#with_context`
             Extract the root form surrounding the cursor as you type to
             provide local context aware completions (such as local let block

--- a/doc/conjure-client-fennel-aniseed.txt
+++ b/doc/conjure-client-fennel-aniseed.txt
@@ -74,6 +74,7 @@ CONFIGURATION                    *conjure-client-fennel-aniseed-configuration*
 
 All configuration can be set as described in |conjure-configuration|.
 
+                       *g:conjure#client#fennel#aniseed#aniseed_module_prefix*
 `g:conjure#client#fennel#aniseed#aniseed_module_prefix`
             Prefix to put in front of all Aniseed modules Conjure relies on.
             This is set to use Conjure's internal copy of Aniseed by default
@@ -82,6 +83,7 @@ All configuration can be set as described in |conjure-configuration|.
             within your project.
             Default: `"conjure.aniseed."`
 
+                                *g:conjure#client#fennel#aniseed#use_metadata*
 `g:conjure#client#fennel#aniseed#use_metadata`
             Enables metadata during evaluation which can provide some
             documentation lookup with Conjure's documentation mapping.
@@ -89,10 +91,12 @@ All configuration can be set as described in |conjure-configuration|.
             Conjure is intended to be used during development.
             Default: `true`
 
+                       *g:conjure#client#fennel#aniseed#mapping#run_buf_tests*
 `g:conjure#client#fennel#aniseed#mapping#run_buf_tests`
             Run all tests within your current module.
             Default: `"tt"`
 
+                       *g:conjure#client#fennel#aniseed#mapping#run_all_tests*
 `g:conjure#client#fennel#aniseed#mapping#run_all_tests`
             Run all loaded tests.
             Default: `"ta"`

--- a/doc/conjure-client-fennel-stdio.txt
+++ b/doc/conjure-client-fennel-stdio.txt
@@ -50,23 +50,28 @@ CONFIGURATION                      *conjure-client-fennel-stdio-configuration*
 All configuration can be set as described in |conjure-configuration|.
 
 
+                                 *g:conjure#client#fennel#stdio#mapping#start*
 `g:conjure#client#fennel#stdio#mapping#start`
             Start the Fennel REPL if it's not running already.
             Default: `"cs"`
 
+                                  *g:conjure#client#fennel#stdio#mapping#stop*
 `g:conjure#client#fennel#stdio#mapping#stop`
             Stop any existing Fennel REPL.
             Default: `"cS"`
 
+                           *g:conjure#client#fennel#stdio#mapping#eval_reload*
 `g:conjure#client#fennel#stdio#mapping#eval_reload`
             Reload the current file.
             Default: `"eF"`
 
+                                       *g:conjure#client#fennel#stdio#command*
 `g:conjure#client#fennel#stdio#command`
             Command used to start the Fennel REPL, you can modify this to add
             arguments or change the command entirely.
             Default: `"fennel"`
 
+                                *g:conjure#client#fennel#stdio#prompt_pattern*
 `g:conjure#client#fennel#stdio#prompt_pattern`
             Lua pattern to identify a new REPL prompt. This match signals to
             Conjure that the previous evaluation is complete and we're ready

--- a/doc/conjure-client-guile-socket.txt
+++ b/doc/conjure-client-guile-socket.txt
@@ -51,14 +51,17 @@ CONFIGURATION                      *conjure-client-guile-socket-configuration*
 All configuration can be set as described in |conjure-configuration|.
 
 
+                                 *g:conjure#client#guile#socket#mapping#start*
 `g:conjure#client#guile#socket#mapping#start`
             Connect to Guile REPL
             Default: `"cs"`
 
+                                  *g:conjure#client#guile#socket#mapping#stop*
 `g:conjure#client#guile#socket#mapping#stop`
             Disconnect from Guile REPL
             Default: `"cS"`
 
+                                      *g:conjure#client#guile#socket#pipename*
 `g:conjure#client#guile#socket#pipename`
             Default path to your Guile socket used when connecting. Guile
             requires this path to be absolute!

--- a/doc/conjure-client-hy-stdio.txt
+++ b/doc/conjure-client-hy-stdio.txt
@@ -46,19 +46,23 @@ CONFIGURATION                          *conjure-client-hy-stdio-configuration*
 All configuration can be set as described in |conjure-configuration|.
 
 
+                                     *g:conjure#client#hy#stdio#mapping#start*
 `g:conjure#client#hy#stdio#mapping#start`
             Start the Hy REPL if it's not running already.
             Default: `"cs"`
 
+                                      *g:conjure#client#hy#stdio#mapping#stop*
 `g:conjure#client#hy#stdio#mapping#stop`
             Stop any existing Hy REPL.
             Default: `"cS"`
 
+                                           *g:conjure#client#hy#stdio#command*
 `g:conjure#client#hy#stdio#command`
             Command used to start the Hy REPL, you can modify this to add
             arguments or change the command entirely.
             Default: `"hy --repl-output-fn=hy.contrib.hy-repr.hy-repr"`
 
+                                    *g:conjure#client#hy#stdio#prompt_pattern*
 `g:conjure#client#hy#stdio#prompt_pattern`
             Lua pattern to identify a new REPL prompt. This match signals to
             Conjure that the previous evaluation is complete and we're ready

--- a/doc/conjure-client-janet-netrepl.txt
+++ b/doc/conjure-client-janet-netrepl.txt
@@ -56,20 +56,24 @@ CONFIGURATION                     *conjure-client-janet-netrepl-configuration*
 
 All configuration can be set as described in |conjure-configuration|.
 
+                      *g:conjure#client#janet#netrepl#connection#default_host*
 `g:conjure#client#janet#netrepl#connection#default_host`
             Host to use when connecting by default. Same as the default
             `spork/netrepl` uses.
             Default: `"127.0.0.1"`
 
+                      *g:conjure#client#janet#netrepl#connection#default_port*
 `g:conjure#client#janet#netrepl#connection#default_port`
             Port to use when connecting by default. Same as the default
             `spork/netrepl` uses.
             Default: `"9365"`
 
+                              *g:conjure#client#janet#netrepl#mapping#connect*
 `g:conjure#client#janet#netrepl#mapping#connect`
             Connect to a running netrepl using the default host and port.
             Default: `"cc"`
 
+                           *g:conjure#client#janet#netrepl#mapping#disconnect*
 `g:conjure#client#janet#netrepl#mapping#disconnect`
             Disconnect from the current netrepl.
             Default: `"cd"`

--- a/doc/conjure-client-racket-stdio.txt
+++ b/doc/conjure-client-racket-stdio.txt
@@ -43,19 +43,23 @@ CONFIGURATION                      *conjure-client-racket-stdio-configuration*
 All configuration can be set as described in |conjure-configuration|.
 
 
+                                 *g:conjure#client#racket#stdio#mapping#start*
 `g:conjure#client#racket#stdio#mapping#start`
             Start the Racket REPL if it's not running already.
             Default: `"cs"`
 
+                                  *g:conjure#client#racket#stdio#mapping#stop*
 `g:conjure#client#racket#stdio#mapping#stop`
             Stop any existing Racket REPL.
             Default: `"cS"`
 
+                                       *g:conjure#client#racket#stdio#command*
 `g:conjure#client#racket#stdio#command`
             Command used to start the Racket REPL, you can modify this to add
             arguments or change the command entirely.
             Default: `"racket"`
 
+                                *g:conjure#client#racket#stdio#prompt_pattern*
 `g:conjure#client#racket#stdio#prompt_pattern`
             Lua pattern to identify a new REPL prompt. This match signals to
             Conjure that the previous evaluation is complete and we're ready

--- a/doc/conjure-client-scheme-stdio.txt
+++ b/doc/conjure-client-scheme-stdio.txt
@@ -42,14 +42,17 @@ CONFIGURATION                      *conjure-client-scheme-stdio-configuration*
 
 All configuration can be set as described in |conjure-configuration|.
 
+                                 *g:conjure#client#scheme#stdio#mapping#start*
 `g:conjure#client#scheme#stdio#mapping#start`
             Start the Scheme REPL if it's not running already.
             Default: `"cs"`
 
+                                  *g:conjure#client#scheme#stdio#mapping#stop*
 `g:conjure#client#scheme#stdio#mapping#stop`
             Stop any existing Scheme REPL.
             Default: `"cS"`
 
+                                       *g:conjure#client#scheme#stdio#command*
 `g:conjure#client#scheme#stdio#command`
             Command used to start the Scheme REPL, you can modify this to add
             arguments or change the command entirely.
@@ -61,6 +64,7 @@ All configuration can be set as described in |conjure-configuration|.
 
             Default: `"mit-scheme"`
 
+                                *g:conjure#client#scheme#stdio#prompt_pattern*
 `g:conjure#client#scheme#stdio#prompt_pattern`
             Lua pattern to identify a new REPL prompt. This match signals to
             Conjure that the previous evaluation is complete and we're ready

--- a/doc/conjure.txt
+++ b/doc/conjure.txt
@@ -49,14 +49,17 @@ open a buffer.
 
 I've also included some commands since they're related to the mappings.
 
+                                                              *:ConjureSchool*
 :ConjureSchool           Start the interactive tutorial which will walk you
                          through the workflow and mappings Conjure provides.
 
+                                                                *:ConjureEval*
 :ConjureEval [code]      Evaluates the given code in the current buffer's
                          language and context. Accepts a range so
                          `:%ConjureEval` would evaluate the entire buffer,
                          this also works with visual selections.
 
+                                                             *:ConjureConnect*
 :ConjureConnect [host] [port]
                          Connect to the given host and port. Both arguments
                          tend to be optional but this can vary depending on
@@ -66,6 +69,7 @@ I've also included some commands since they're related to the mappings.
                          `:ConjureConnect 5678`
                          `:ConjureConnect staging.my-app.com 5678`
 
+                                                         *:ConjureClientState*
 :ConjureClientState [state-key]
                          Get or set (if an argument is provided) the current
                          client state key. This defaults to `default` and can
@@ -220,6 +224,7 @@ defined as you enter a buffer and can't be altered after the fact.
 
 Tip: Booleans in Vim Script are written as `v:true` and `v:false`.
 
+                                                         *g:conjure#filetypes*
 `g:conjure#filetypes`
             A list of filetypes Conjure should be associated with. Conjure
             will then look up which client module to use for this filetype
@@ -233,11 +238,13 @@ Tip: Booleans in Vim Script are written as `v:true` and `v:false`.
 
             Default: `["clojure", "fennel", "janet", "racket", "scheme"]`
 
+                                                  *g:conjure#filetype#clojure*
 `g:conjure#filetype#clojure`
             Client to use for `clojure` buffers.
             Help: |conjure-client-clojure-nrepl|
             Default: `"conjure.client.clojure.nrepl"`
 
+                                                   *g:conjure#filetype#fennel*
 `g:conjure#filetype#fennel`
             Client to use for `fennel` buffers. Conjure also ships with an
             alternative `"conjure.client.fennel.stdio"` client which allows
@@ -246,16 +253,19 @@ Tip: Booleans in Vim Script are written as `v:true` and `v:false`.
             Help: |conjure-client-fennel-aniseed|, |conjure-client-fennel-stdio|
             Default: `"conjure.client.fennel.aniseed"`
 
+                                                    *g:conjure#filetype#janet*
 `g:conjure#filetype#janet`
             Client to use for `janet` buffers.
             Help: |conjure-client-janet-netrepl|
             Default: `"conjure.client.janet.netrepl"`
 
+                                                       *g:conjure#filetype#hy*
 `g:conjure#filetype#hy`
             Client to use for `hy` buffers.
             Help: |conjure-client-hy-stdio|
             Default: `"conjure.client.hy.stdio"`
 
+                                                   *g:conjure#filetype#scheme*
 `g:conjure#filetype#scheme`
             Client to use for `scheme` buffers. You can use Guile over a
             socket file instead by setting this to
@@ -263,11 +273,13 @@ Tip: Booleans in Vim Script are written as `v:true` and `v:false`.
             Help: |conjure-client-scheme-stdio|, |conjure-client-guile-socket|
             Default: `"conjure.client.scheme.stdio"`
 
+                                                   *g:conjure#filetype#racket*
 `g:conjure#filetype#racket`
             Client to use for `racket` buffers.
             Help: |conjure-client-racket-stdio|
             Default: `"conjure.client.racket.stdio"`
 
+                                      *g:conjure#filetype_suffixes#[filetype]*
 `g:conjure#filetype_suffixes#[filetype]`
             If a client is loading when it shouldn't we can configure that
             filetype to match a specific set of file extensions. This is
@@ -276,18 +288,21 @@ Tip: Booleans in Vim Script are written as `v:true` and `v:false`.
             difficult to determine which client we should use.
             Default: `nil`
 
+                                          *g:conjure#filetype_suffixes#racket*
 `g:conjure#filetype_suffixes#racket`
             Racket filetype support cycles between the `scheme` and `racket`
             filetypes at times, this list restricts the Racket client to the
             right paths as well as filetypes.
             Default: `["rkt"]`
 
+                                          *g:conjure#filetype_suffixes#scheme*
 `g:conjure#filetype_suffixes#scheme`
             We don't want the Scheme client to activate for Racket or Guile
             buffers, which both sometimes flick their filetype to `scheme`
             just to try and confuse us. But we're ready for it!
             Default: `["scm"]`
 
+                                              *g:conjure#eval#result_register*
 `g:conjure#eval#result_register`
             Every evaluation captures the result and places it in a Neovim
             register for you to use however you want. By default, if you
@@ -299,12 +314,14 @@ Tip: Booleans in Vim Script are written as `v:true` and `v:false`.
              * `"_"` the black hole when you don't want this at all.
             Default: `"c"`
 
+                                               *g:conjure#eval#inline_results*
 `g:conjure#eval#inline_results`
             Displays the results of evaluations inline as virtual text at the
             end of the line where the evaluation was initiated.
             Example: `(+ 10 20) => 30`
             Default: `true`
 
+                                               *g:conjure#eval#comment_prefix*
 `g:conjure#eval#comment_prefix`
             The comment prefix to use for "eval and insert result as comment"
             mappings. Defaults to whatever comment character (normally
@@ -313,6 +330,7 @@ Tip: Booleans in Vim Script are written as `v:true` and `v:false`.
             space!).
             Default: `nil` (whatever comment character the language uses)
 
+                                                        *g:conjure#eval#gsubs*
 `g:conjure#eval#gsubs`
             Lua `string.gsub` modifications to make to code before it's
             evaluated. For example, the following will mean you can evaluate
@@ -333,103 +351,127 @@ Tip: Booleans in Vim Script are written as `v:true` and `v:false`.
 
             More on Lua patterns: https://www.lua.org/pil/20.2.html
 
+                                                    *g:conjure#mapping#prefix*
 `g:conjure#mapping#prefix`
             The key that proceeds most mappings.
             Default: `"<localleader>"`
 
+                                                 *g:conjure#mapping#log_split*
 `g:conjure#mapping#log_split`
             Opens the log in a horizontal split.
             Default: `"ls"`
 
+                                                *g:conjure#mapping#log_vsplit*
 `g:conjure#mapping#log_vsplit`
             Opens the log in a vertical split.
             Default: `"lv"`
 
+                                                   *g:conjure#mapping#log_tab*
 `g:conjure#mapping#log_tab`
             Opens the log in a new tab.
             Default: `"lt"`
 
+                                            *g:conjure#mapping#log_reset_soft*
 `g:conjure#mapping#log_reset_soft`
             Soft reset the log buffer by wiping the contents.
             Default: `"lr"`
 
+                                            *g:conjure#mapping#log_reset_hard*
 `g:conjure#mapping#log_reset_hard`
             Hard reset the log buffer by deleting the entire buffer.
             Default: `"lR"`
 
+                                         *g:conjure#mapping#log_close_visible*
 `g:conjure#mapping#log_close_visible`
             Close all visible log windows.
             Default: `"lq"`
 
+                                         *g:conjure#mapping#eval_current_form*
 `g:conjure#mapping#eval_current_form`
             Evaluates the form under the cursor.
             Default: `"ee"`
 
+                                 *g:conjure#mapping#eval_comment_current_form*
 `g:conjure#mapping#eval_comment_current_form`
             Evaluates the form under the cursor and inserts the result as a
             comment.
             Default: `"ece"`
 
+                                            *g:conjure#mapping#eval_root_form*
 `g:conjure#mapping#eval_root_form`
             Evaluates the root form under the cursor.
             Default: `"er"`
 
+                                    *g:conjure#mapping#eval_comment_root_form*
 `g:conjure#mapping#eval_comment_root_form`
             Evaluates the root form under the cursor and inserts the result as
             a comment.
             Default: `"ecr"`
 
+                                                 *g:conjure#mapping#eval_word*
 `g:conjure#mapping#eval_word`
             Evaluates the word under the cursor.
             Default: `"ew"`
 
+                                         *g:conjure#mapping#eval_comment_word*
 `g:conjure#mapping#eval_comment_word`
             Evaluates the word under the cursor and inserts the result as a
             comment.
             Default: `"ecw"`
 
+                                         *g:conjure#mapping#eval_replace_form*
 `g:conjure#mapping#eval_replace_form`
             Evaluates the form under the cursor and replace with the result.
             Default: `"e!"`
 
+                                          *g:conjure#mapping#eval_marked_form*
 `g:conjure#mapping#eval_marked_form`
             Evaluates the form at the marks location.
             Default: `"em"`
 
+                                         *g:conjure#mapping#eval_comment_form*
 `g:conjure#mapping#eval_comment_form`
             Evaluates the form under the cursor and displays the result as a
             comment at the end of the current line or below the current line.
             Default: `"ec"`
 
+                                                 *g:conjure#mapping#eval_file*
 `g:conjure#mapping#eval_file`
             Evaluates the file from disk.
             Default: `"ef"`
 
+                                                  *g:conjure#mapping#eval_buf*
 `g:conjure#mapping#eval_buf`
             Evaluates the buffer from memory.
             Default: `"eb"`
 
+                                               *g:conjure#mapping#eval_visual*
 `g:conjure#mapping#eval_visual`
             Evaluates the visual selection.
             Default: `"E"`
 
+                                               *g:conjure#mapping#eval_motion*
 `g:conjure#mapping#eval_motion`
             Evaluates the following motion.
             Default: `"E"`
 
+                                                  *g:conjure#mapping#def_word*
 `g:conjure#mapping#def_word`
             Goes to the definition of the word under the cursor.
             Default: `"gd"`
 
+                                                  *g:conjure#mapping#doc_word*
 `g:conjure#mapping#doc_word`
             Looks up documentation for the word under the cursor.
             Default: `["K"]`
 
+                                               *g:conjure#completion#omnifunc*
 `g:conjure#completion#omnifunc`
             |omnifunc| to set for supported Conjure clients. No omnicompletion
             will be provided if you set this to `nil`.
             Default: `"ConjureOmnifunc"`
 
+                                               *g:conjure#completion#fallback*
 `g:conjure#completion#fallback`
             |omnifunc| to use if the client isn't returning completions,
             requires `completion#omnifunc` to be set to `"ConjureOmnifunc"`. For
@@ -437,39 +479,47 @@ Tip: Booleans in Vim Script are written as `v:true` and `v:false`.
             this kicks in if you don't have an nREPL connection yet.
             Default: `"syntaxcomplete#Complete"`
 
+                                                 *g:conjure#highlight#enabled*
 `g:conjure#highlight#enabled`
             Enable highlighting of evaluated forms. Requires support for the
             highlight API, so you'll need Neovim 0.5+.
             Default: `false`
 
+                                                   *g:conjure#highlight#group*
 `g:conjure#highlight#group`
             Which syntax group should the form be highlighted with.
             Default: `"IncSearch"`
 
+                                                 *g:conjure#highlight#timeout*
 `g:conjure#highlight#timeout`
             How long should the highlight last in milliseconds.
             Default: `500`
 
+                                                     *g:conjure#log#hud#width*
 `g:conjure#log#hud#width`
             Width of the HUD as a percentage of the editor width.
             A float between 0.0 and 1.0.
             Default: `0.42`
 
+                                                    *g:conjure#log#hud#height*
 `g:conjure#log#hud#height`
             Height of the HUD as a percentage of the editor height.
             A float between 0.0 and 1.0.
             Default: `0.3`
 
+                                                   *g:conjure#log#hud#enabled*
 `g:conjure#log#hud#enabled`
             Should the HUD be displayed at all.
             Default: `true`
 
+                                       *g:conjure#log#hud#passive_close_delay*
 `g:conjure#log#hud#passive_close_delay`
             Delay to introduce (in milliseconds) when closing the HUD
             passively such as after you move the cursor. Set it to `0` to
             disable the mechanic entirely and close instantly.
             Default: `0`
 
+                                           *g:conjure#log#hud#overlap_padding*
 `g:conjure#log#hud#overlap_padding`
             Extra space checked around the HUD window for the cursor. If it's
             within this padded boundary (too close to the HUD) it'll move to
@@ -477,6 +527,7 @@ Tip: Booleans in Vim Script are written as `v:true` and `v:false`.
             A float between 0.0 and 1.0.
             Default: `0.1`
 
+                                                    *g:conjure#log#hud#anchor*
 `g:conjure#log#hud#anchor`
             Preferred corner position for the HUD. This is not guaranteed, it
             will try to move out of the way to avoid covering your cursor and
@@ -485,24 +536,29 @@ Tip: Booleans in Vim Script are written as `v:true` and `v:false`.
             window width HUD at the bottom of the screen.
             Default: `"NE"`
 
+                                                      *g:conjure#log#botright*
 `g:conjure#log#botright`
             Force the log to always open at the bottom or far right of the
             editor, taking up the full width or height respectively.
             Default: `false`
 
+                                                  *g:conjure#log#break_length*
 `g:conjure#log#break_length`
             Length of the break comment (`; ---------...`) between log results
             in characters. Used in trimming to avoid cutting forms in half.
             Default: `80`
 
+                                                       *g:conjure#log#trim#at*
 `g:conjure#log#trim#at`
             Trim the log once the line count passes the value.
             Default: `10000`
 
+                                                       *g:conjure#log#trim#to*
 `g:conjure#log#trim#to`
             Trim the log down to this many lines when it gets too long.
             Default: `7000`
 
+                        *g:conjure#log#strip_ansi_escape_sequences_line_limit*
 `g:conjure#log#strip_ansi_escape_sequences_line_limit`
             If the chunk of text being appended to the log is less than this
             many lines in length, strip all ANSI escape sequences from it. If
@@ -513,26 +569,32 @@ Tip: Booleans in Vim Script are written as `v:true` and `v:false`.
             doesn't contain escape sequences) from slowing down your log.
             Default: `100`
 
+                                                          *g:conjure#log#wrap*
 `g:conjure#log#wrap`
             Enable line wrapping in the HUD and log.
             Default: `false`
 
+                                                  *g:conjure#log#fold#enabled*
 `g:conjure#log#fold#enabled`
             Enable or disable folding of results.
             Default: `false`
 
+                                                    *g:conjure#log#fold#lines*
 `g:conjure#log#fold#lines`
             Fold results that have a line count >= this value.
             Default: `10`
 
+                                             *g:conjure#log#fold#marker#start*
 `g:conjure#log#fold#marker#start`
             Marker to use to represent the start of a log fold.
             Default: `"~~~%{"`
 
+                                               *g:conjure#log#fold#marker#end*
 `g:conjure#log#fold#marker#end`
             Marker to use to represent the end of a log fold.
             Default: `"}%~~~"`
 
+                                      *g:conjure#extract#context_header_lines*
 `g:conjure#extract#context_header_lines`
             How many lines of the file should be checked for a context
             (namespace name) such as `(module foo.bar)` or `(ns foo.bar)`
@@ -543,6 +605,7 @@ Tip: Booleans in Vim Script are written as `v:true` and `v:false`.
             can override it by setting `b:conjure#context`.
             Default: `24`
 
+                                                *g:conjure#extract#form_pairs*
 `g:conjure#extract#form_pairs`
             Character pairs to search for when evaluating forms. The closest
             matching pair is used when evaluating the current form but the
@@ -552,6 +615,7 @@ Tip: Booleans in Vim Script are written as `v:true` and `v:false`.
             enable escaping for use in |searchpairpos()|.
             Default: `[["(" ")"] ["{" "}"] ["[" "]" true]]`
 
+                                       *g:conjure#extract#tree_sitter#enabled*
 `g:conjure#extract#tree_sitter#enabled`
             Enable tree-sitter support for extracting code from the buffer.
             This is used by non-Lisp clients to find the appropriate chunk of
@@ -570,6 +634,7 @@ Tip: Booleans in Vim Script are written as `v:true` and `v:false`.
 
             Default: `false`
 
+                                              *g:conjure#preview#sample_limit*
 `g:conjure#preview#sample_limit`
             Most evaluation actions create a line in the log buffer with a
             preview of the code that was evaluated as a reminder. This setting
@@ -580,6 +645,7 @@ Tip: Booleans in Vim Script are written as `v:true` and `v:false`.
             A float between 0.0 and 1.0.
             Default: `0.3`
 
+                                                *g:conjure#relative_file_root*
 `g:conjure#relative_file_root`
             If set, Conjure will attempt to resolve absolute file paths to a
             relative path based on this value. This means you can evaluate
@@ -598,6 +664,7 @@ Tip: Booleans in Vim Script are written as `v:true` and `v:false`.
 
             Default: `undefined`
 
+                                                         *g:conjure#path_subs*
 `g:conjure#path_subs`
             If set Conjure will modify paths on "go to definition" as well as
             "eval file". The path will be substituted using Lua's
@@ -618,10 +685,12 @@ Tip: Booleans in Vim Script are written as `v:true` and `v:false`.
 
             Default: `undefined`
 
+                                                             *g:conjure#debug*
 `g:conjure#debug`
             Display debug information in any client you're using.
             Default: `false`
 
+                                                           *b:conjure#context*
 `b:conjure#context`
             Override the context name for a specific buffer, preventing
             Conjure from attempting to extract it from the first few lines
@@ -681,19 +750,24 @@ If there's an event you need and think would be a good general fit for the
 project, feel free to raise an issue to discuss it (and potentially submit a
 pull request if we agree!).
 
+                                                                 *ConjureEval*
 `ConjureEval`
             After an evaluation of any kind.
 
+                                                             *ConjureEvalFile*
 `ConjureEvalFile`
             After an evaluation of a file from disk.
 
+                                                              *ConjureEvalStr*
 `ConjureEvalStr`
             After an evaluation of an arbitrary string (from evaluating a
             form, buffer, range, command etc).
 
+                                                                  *ConjureDoc*
 `ConjureDoc`
             After requesting documentation.
 
+                                                                  *ConjureDef*
 `ConjureDef`
             After requesting definition lookup.
 


### PR DESCRIPTION
I find help tags for commands and configuration options very useful:

* easier to point somebody to a specific option like `:help g:conjure#log#wrap`
* allows jumping to documentation using `K` right from usage in init.vim
* allows jumping to mentions inside documentation using `K` or `Ctrl-]`
* makes options and commands more discoverable using `Helptags` from fzf-vim, vim-clap, or telescope