### PR TITLE
Fix #249, `log-buf?` in `log.fnl`

### DIFF
--- a/fnl/conjure/log.fnl
+++ b/fnl/conjure/log.fnl
@@ -26,7 +26,8 @@
   (.. "conjure-log-" (nvim.fn.getpid) (client.get :buf-suffix)))
 
 (defn log-buf? [name]
-  (name:match (.. (log-buf-name) "$")))
+  (let [log-buf-name-sanitized (string.gsub (log-buf-name) "%-" "%%-")]
+    (name:match (.. log-buf-name-sanitized "$"))))
 
 (defn- on-new-log-buf [buf]
   (nvim.buf_set_lines

--- a/lua/conjure/log.lua
+++ b/lua/conjure/log.lua
@@ -38,7 +38,8 @@ local function log_buf_name()
 end
 _2amodule_locals_2a["log-buf-name"] = log_buf_name
 local function log_buf_3f(name)
-  return name:match((log_buf_name() .. "$"))
+  local log_buf_name_sanitized = string.gsub(log_buf_name(), "%-", "%%-")
+  return name:match((log_buf_name_sanitized .. "$"))
 end
 _2amodule_2a["log-buf?"] = log_buf_3f
 local function on_new_log_buf(buf)


### PR DESCRIPTION
Previously, conjure would `,enter` even log files for Racket.
This was because the function `log-buf?` in log.fnl used
the match method for strings, and log-buf names contain
'-' (hyphen) symbols, which are metacharacters in lua
pattern matching.

Sanitizing the buffer name by escaping the hyphen before
checking solves the issue.