### PR TITLE
Send line/column and file path of evaluated code to Janet's netrepl server

### DIFF
--- a/fnl/conjure/client/janet/netrepl.fnl
+++ b/fnl/conjure/client/janet/netrepl.fnl
@@ -51,9 +51,9 @@
 (defn- send [msg cb row col file-path]
   (with-conn-or-warn
     (fn [conn]
-      (remote.send conn (.. "\xFF(parser/where (dyn :parser) " row " " col ")") (fn [msg] nil))
-      ; (remote.send conn (.. "\xFEsource " "\"/path/to/file.janet\"") cb)
-      (remote.send conn msg cb))))
+      (remote.send conn (.. "\xFF(parser/where (dyn :parser) " row " " col ")"))
+      (remote.send conn (.. "\xFEsource \"" file-path "\"") nil true)
+      (remote.send conn msg cb true))))
 
 (defn connect [opts]
   (let [opts (or opts {})

--- a/fnl/conjure/remote/netrepl.fnl
+++ b/fnl/conjure/remote/netrepl.fnl
@@ -5,10 +5,13 @@
             client conjure.client
             trn conjure.remote.transport.netrepl}})
 
-(defn send [conn msg cb]
-  "Send a message to the given connection, call the callback when a response is received."
+(defn send [conn msg cb prompt?]
+  "Send a message to the given connection, call the callback when a response is received.
+  If a prompt is expected in addition to the response, prompt? should be set to true."
   (log.dbg "send" msg)
   (table.insert conn.queue 1 (or cb false))
+  (when prompt?
+    (table.insert conn.queue 1 false))
   (conn.sock:write (trn.encode msg))
   nil)
 

--- a/lua/conjure/client/janet/netrepl.lua
+++ b/lua/conjure/client/janet/netrepl.lua
@@ -67,11 +67,9 @@ end
 _2amodule_2a["disconnect"] = disconnect
 local function send(msg, cb, row, col, file_path)
   local function _6_(conn)
-    local function _7_(msg0)
-      return nil
-    end
-    remote.send(conn, ("\255(parser/where (dyn :parser) " .. row .. " " .. col .. ")"), _7_)
-    return remote.send(conn, msg, cb)
+    remote.send(conn, ("\255(parser/where (dyn :parser) " .. row .. " " .. col .. ")"))
+    remote.send(conn, ("\254source \"" .. file_path .. "\""), nil, true)
+    return remote.send(conn, msg, cb, true)
   end
   return with_conn_or_warn(_6_)
 end
@@ -84,21 +82,21 @@ local function connect(opts)
     disconnect()
   else
   end
-  local function _9_(err)
+  local function _8_(err)
     display_conn_status(err)
     return disconnect()
   end
-  local function _10_()
+  local function _9_()
     return display_conn_status("connected")
   end
-  local function _11_(err)
+  local function _10_(err)
     if err then
       return display_conn_status(err)
     else
       return disconnect()
     end
   end
-  return a.assoc(state(), "conn", remote.connect({host = host, port = port, ["on-failure"] = _9_, ["on-success"] = _10_, ["on-error"] = _11_}))
+  return a.assoc(state(), "conn", remote.connect({host = host, port = port, ["on-failure"] = _8_, ["on-success"] = _9_, ["on-error"] = _10_}))
 end
 _2amodule_2a["connect"] = connect
 local function try_ensure_conn()
@@ -111,7 +109,7 @@ end
 _2amodule_locals_2a["try-ensure-conn"] = try_ensure_conn
 local function eval_str(opts)
   try_ensure_conn()
-  local function _14_(msg)
+  local function _13_(msg)
     local clean = text["trim-last-newline"](msg)
     if opts["on-result"] then
       opts["on-result"](text["strip-ansi-escape-sequences"](clean))
@@ -123,15 +121,15 @@ local function eval_str(opts)
       return nil
     end
   end
-  return send((opts.code .. "\n"), _14_, (a["get-in"](opts.range, {"start", 1}) or 1), (a["get-in"](opts.range, {"start", 2}) or 1), opts["file-path"])
+  return send((opts.code .. "\n"), _13_, (a["get-in"](opts.range, {"start", 1}) or 1), (a["get-in"](opts.range, {"start", 2}) or 1), opts["file-path"])
 end
 _2amodule_2a["eval-str"] = eval_str
 local function doc_str(opts)
   try_ensure_conn()
-  local function _17_(_241)
+  local function _16_(_241)
     return ("(doc " .. _241 .. ")")
   end
-  return eval_str(a.update(opts, "code", _17_))
+  return eval_str(a.update(opts, "code", _16_))
 end
 _2amodule_2a["doc-str"] = doc_str
 local function eval_file(opts)

--- a/lua/conjure/client/janet/netrepl.lua
+++ b/lua/conjure/client/janet/netrepl.lua
@@ -65,8 +65,12 @@ local function disconnect()
   return with_conn_or_warn(_5_)
 end
 _2amodule_2a["disconnect"] = disconnect
-local function send(msg, cb)
+local function send(msg, cb, row, col, file_path)
   local function _6_(conn)
+    local function _7_(msg0)
+      return nil
+    end
+    remote.send(conn, ("\255(parser/where (dyn :parser) " .. row .. " " .. col .. ")"), _7_)
     return remote.send(conn, msg, cb)
   end
   return with_conn_or_warn(_6_)
@@ -80,21 +84,21 @@ local function connect(opts)
     disconnect()
   else
   end
-  local function _8_(err)
+  local function _9_(err)
     display_conn_status(err)
     return disconnect()
   end
-  local function _9_()
+  local function _10_()
     return display_conn_status("connected")
   end
-  local function _10_(err)
+  local function _11_(err)
     if err then
       return display_conn_status(err)
     else
       return disconnect()
     end
   end
-  return a.assoc(state(), "conn", remote.connect({host = host, port = port, ["on-failure"] = _8_, ["on-success"] = _9_, ["on-error"] = _10_}))
+  return a.assoc(state(), "conn", remote.connect({host = host, port = port, ["on-failure"] = _9_, ["on-success"] = _10_, ["on-error"] = _11_}))
 end
 _2amodule_2a["connect"] = connect
 local function try_ensure_conn()
@@ -107,7 +111,7 @@ end
 _2amodule_locals_2a["try-ensure-conn"] = try_ensure_conn
 local function eval_str(opts)
   try_ensure_conn()
-  local function _13_(msg)
+  local function _14_(msg)
     local clean = text["trim-last-newline"](msg)
     if opts["on-result"] then
       opts["on-result"](text["strip-ansi-escape-sequences"](clean))
@@ -119,15 +123,15 @@ local function eval_str(opts)
       return nil
     end
   end
-  return send((opts.code .. "\n"), _13_)
+  return send((opts.code .. "\n"), _14_, (a["get-in"](opts.range, {"start", 1}) or 1), (a["get-in"](opts.range, {"start", 2}) or 1), opts["file-path"])
 end
 _2amodule_2a["eval-str"] = eval_str
 local function doc_str(opts)
   try_ensure_conn()
-  local function _16_(_241)
+  local function _17_(_241)
     return ("(doc " .. _241 .. ")")
   end
-  return eval_str(a.update(opts, "code", _16_))
+  return eval_str(a.update(opts, "code", _17_))
 end
 _2amodule_2a["doc-str"] = doc_str
 local function eval_file(opts)

--- a/lua/conjure/remote/netrepl.lua
+++ b/lua/conjure/remote/netrepl.lua
@@ -17,9 +17,13 @@ _2amodule_locals_2a["client"] = client
 _2amodule_locals_2a["log"] = log
 _2amodule_locals_2a["net"] = net
 _2amodule_locals_2a["trn"] = trn
-local function send(conn, msg, cb)
+local function send(conn, msg, cb, prompt_3f)
   log.dbg("send", msg)
   table.insert(conn.queue, 1, (cb or false))
+  if prompt_3f then
+    table.insert(conn.queue, 1, false)
+  else
+  end
   do end (conn.sock):write(trn.encode(msg))
   return nil
 end
@@ -30,7 +34,7 @@ local function connect(opts)
     if (err or not chunk) then
       return opts["on-error"](err)
     else
-      local function _1_(msg)
+      local function _2_(msg)
         log.dbg("receive", msg)
         local cb = table.remove(conn.queue)
         if cb then
@@ -39,10 +43,10 @@ local function connect(opts)
           return nil
         end
       end
-      return a["run!"](_1_, conn.decode(chunk))
+      return a["run!"](_2_, conn.decode(chunk))
     end
   end
-  local function _4_(err)
+  local function _5_(err)
     if err then
       return opts["on-failure"](err)
     else
@@ -50,7 +54,7 @@ local function connect(opts)
       return opts["on-success"]()
     end
   end
-  conn = a.merge(conn, net.connect({host = opts.host, port = opts.port, cb = client["schedule-wrap"](_4_)}))
+  conn = a.merge(conn, net.connect({host = opts.host, port = opts.port, cb = client["schedule-wrap"](_5_)}))
   send(conn, (opts.name or "Conjure"))
   return conn
 end


### PR DESCRIPTION
This PR does two things:

- [x] Sets the line and column number of the parser object used by Janet's netrepl to parse the received code.
- [x] Sets the file path of the file being evaluated that is used when generating error messages.

### Setting the line and column number

Prior to the code being sent to the netrepl server for evaluation, the parser's row and column numbers are set to the value in `opts.range.start` (if either of these values are `nil`, `1` is used instead). This is done by sending a message prepended with `\xFF`. Messages of this type generate one response message: the result of evaluation.

### Setting the file path

Prior to the code being sent to the netrepl server for evaluation, the parser's source is updated to the value in `opts.file-path`. This is done by sending a message prepended with `\xFE`. Messages of this type generate two response messages: the result of the evaluation and the prompt.

### Handling prompts

As indicated above, some messages that are sent to the netrepl server generate one response message and some generate two response messages. This can cause issues because Conjure puts the callback used to print values to the log in a queue (really a table) and removes the callbacks from the queue as messages come in. We don't see a problem at present because the additional message that comes in (the prompt) can be ignored. However, if multiple messages are sent, this may no longer the case. The change made by this PR is to add a `prompt?` argument to the function `send` in the `conjure.remote.netrepl` module. The caller can now specify that a prompt is expected and a placeholder value (i.e. `false`) is put into the queue.

This PR closes #147.