### PR TITLE
Run tests will respect raw-out setting

### DIFF
--- a/fnl/conjure/client/clojure/nrepl/action.fnl
+++ b/fnl/conjure/client/clojure/nrepl/action.fnl
@@ -455,7 +455,8 @@
         #(ui.display-result
            $1
            {:simple-out? true
-            :ignore-nil? true})))))
+            :ignore-nil? true
+            :raw-out? (cfg [:eval :raw_out])})))))
 
 (defn- run-ns-tests [ns]
   (try-ensure-conn
@@ -469,7 +470,8 @@
           #(ui.display-result
              $1
              {:simple-out? true
-              :ignore-nil? true}))))))
+              :ignore-nil? true
+              :raw-out? (cfg [:eval :raw_out])}))))))
 
 (defn run-current-ns-tests []
   (run-ns-tests (extract.context)))
@@ -514,16 +516,11 @@
                              test-name
                              (test-cfg :name-suffix)))
                  :context (extract.context)}
-                (nrepl.with-all-msgs-fn
-                  (fn [msgs]
-                    (if (and (= 2 (a.count msgs))
-                             (= "nil" (a.get (a.first msgs) :value)))
-                      (log.append ["; Success!"])
-                      (a.run! #(ui.display-result
-                                 $1
-                                 {:simple-out? true
-                                  :ignore-nil? true})
-                              msgs))))))))))))
+                #(ui.display-result
+                   $1
+                   {:simple-out? true
+                    :ignore-nil? false
+                    :raw-out? (cfg [:eval :raw_out])})))))))))
 
 (defn- refresh-impl [op]
   (server.with-conn-and-op-or-warn

--- a/fnl/conjure/client/clojure/nrepl/ui.fnl
+++ b/fnl/conjure/client/clojure/nrepl/ui.fnl
@@ -28,8 +28,8 @@
         (text.prefixed-lines
           (text.trim-last-newline resp.out)
           (if
-            opts.simple-out? "; "
             (or opts.raw-out? (cfg [:eval :raw_out])) ""
+            opts.simple-out? "; "
             "; (out) ")
           {:skip-first? joined?})
 

--- a/lua/conjure/client/clojure/nrepl/ui.lua
+++ b/lua/conjure/client/clojure/nrepl/ui.lua
@@ -50,10 +50,10 @@ local function display_result(resp, opts)
   local _4_
   if resp.out then
     local _5_
-    if opts0["simple-out?"] then
-      _5_ = "; "
-    elseif (opts0["raw-out?"] or cfg({"eval", "raw_out"})) then
+    if (opts0["raw-out?"] or cfg({"eval", "raw_out"})) then
       _5_ = ""
+    elseif opts0["simple-out?"] then
+      _5_ = "; "
     else
       _5_ = "; (out) "
     end


### PR DESCRIPTION
1. For all run tests command in Clojure, the output now will respect the `g:conjure#client#clojure#nrepl#eval#raw_out` setting.
This makes debugging easier IMO.

Examples :
without raw out
![Screen Shot 2021-11-28 at 22 28 19](https://user-images.githubusercontent.com/25661381/143775570-0b90c269-30dc-478b-840b-4569f2729c4c.png)
with raw out
![Screen Shot 2021-11-28 at 22 27 55](https://user-images.githubusercontent.com/25661381/143775573-f4c974b0-279f-454e-8536-08c3bf5eaa0c.png)

2. I also remove the log-append `Success!` if the test is successful because I find logging `nil` is more familiar since it's the default output of `clojure.test/test-vars`.
