### PR TITLE
fix(buffer): pcall bufnr call because bufname can be invalid

### DIFF
--- a/fnl/conjure/buffer.fnl
+++ b/fnl/conjure/buffer.fnl
@@ -14,9 +14,9 @@
   (nvim.buf_get_name (nvim.fn.bufnr buf-name)))
 
 (defn upsert-hidden [buf-name new-buf-fn]
-  (let [buf (nvim.fn.bufnr buf-name)
-        loaded? (nvim.buf_is_loaded buf)]
-    (if (or (= -1 buf) (not loaded?))
+  (let [(ok buf) (pcall nvim.fn.bufnr buf-name)
+        loaded? (and ok (nvim.buf_is_loaded buf))]
+    (if (or (not ok) (or (= -1 buf) (not loaded?)))
       (let [buf (if loaded?
                   buf
                   (nvim.fn.bufadd buf-name))]

--- a/fnl/conjure/buffer.fnl
+++ b/fnl/conjure/buffer.fnl
@@ -14,9 +14,9 @@
   (nvim.buf_get_name (nvim.fn.bufnr buf-name)))
 
 (defn upsert-hidden [buf-name new-buf-fn]
-  (let [(ok buf) (pcall nvim.fn.bufnr buf-name)
-        loaded? (and ok (nvim.buf_is_loaded buf))]
-    (if (or (not ok) (or (= -1 buf) (not loaded?)))
+  (let [(ok? buf) (pcall nvim.fn.bufnr buf-name)
+        loaded? (and ok? (nvim.buf_is_loaded buf))]
+    (if (or (= -1 buf) (not loaded?))
       (let [buf (if loaded?
                   buf
                   (nvim.fn.bufadd buf-name))]

--- a/lua/conjure/buffer.lua
+++ b/lua/conjure/buffer.lua
@@ -25,9 +25,9 @@ local function resolve(buf_name)
 end
 _2amodule_2a["resolve"] = resolve
 local function upsert_hidden(buf_name, new_buf_fn)
-  local buf = nvim.fn.bufnr(buf_name)
-  local loaded_3f = nvim.buf_is_loaded(buf)
-  if ((-1 == buf) or not loaded_3f) then
+  local ok, buf = pcall(nvim.fn.bufnr, buf_name)
+  local loaded_3f = (ok and nvim.buf_is_loaded(buf))
+  if (not ok or ((-1 == buf) or not loaded_3f)) then
     local buf0
     if loaded_3f then
       buf0 = buf

--- a/lua/conjure/buffer.lua
+++ b/lua/conjure/buffer.lua
@@ -25,9 +25,9 @@ local function resolve(buf_name)
 end
 _2amodule_2a["resolve"] = resolve
 local function upsert_hidden(buf_name, new_buf_fn)
-  local ok, buf = pcall(nvim.fn.bufnr, buf_name)
-  local loaded_3f = (ok and nvim.buf_is_loaded(buf))
-  if (not ok or ((-1 == buf) or not loaded_3f)) then
+  local ok_3f, buf = pcall(nvim.fn.bufnr, buf_name)
+  local loaded_3f = (ok_3f and nvim.buf_is_loaded(buf))
+  if ((-1 == buf) or not loaded_3f) then
     local buf0
     if loaded_3f then
       buf0 = buf


### PR DESCRIPTION
Was throwing error with `:set debug=throw` activated.
Fixes #283

I thought i couldn't do it but actually i could :smile:
tests passes, maybe you want me to add another test here ?
Also if you have any suggestion on code quality or how i can do this patch in a better way i'd be happy to take any advice :)