### PR TITLE
Support for inspecting tree-sitter node type

### DIFF
--- a/doc/conjure.txt
+++ b/doc/conjure.txt
@@ -862,6 +862,10 @@ See `fnl/conjure/client/clojure/nrepl/init.fnl` for an example of this.
                  String to be embedded in your evaluation. You can wrap it
                  with whatever padding code you require. This is what the user
                  selected for evaluation.
+             - `opts.node-type`
+                 The tree-sitter node type associated with the string. It's
+                 non-nil only if tree-sitter support is enabled and origin is
+                 one of "current-form", "replace-form", "root-form".
              - `opts.context`
                  String extracted using `context-pattern` or `nil` if nothing
                  could be found. At that point you should default it to

--- a/fnl/conjure/eval.fnl
+++ b/fnl/conjure/eval.fnl
@@ -143,11 +143,12 @@
 (defn current-form [extra-opts]
   (let [form (extract.form {})]
     (when form
-      (let [{: content : range} form]
+      (let [{: content : range : node-type} form]
         (eval-str
           (a.merge
             {:code content
              :range range
+             :node-type node-type
              :origin :current-form}
             extra-opts))
         form))))
@@ -157,10 +158,11 @@
         win (nvim.tabpage_get_win 0)
         form (extract.form {})]
     (when form
-      (let [{: content : range} form]
+      (let [{: content : range : node-type} form]
         (eval-str
           {:code content
            :range range
+           :node-type node-type
            :origin :replace-form
            :suppress-hud? true
            :on-result
@@ -177,10 +179,11 @@
 (defn root-form []
   (let [form (extract.form {:root? true})]
     (when form
-      (let [{: content : range} form]
+      (let [{: content : range : node-type} form]
         (eval-str
           {:code content
            :range range
+           :node-type node-type
            :origin :root-form})))))
 
 (defn marked-form [mark]

--- a/fnl/conjure/extract.fnl
+++ b/fnl/conjure/extract.fnl
@@ -105,7 +105,8 @@
                  (ts.get-form))]
       (when node
         {:range (ts.range node)
-         :content (ts.node->str node)}))
+         :content (ts.node->str node)
+         :node-type (tostring node)}))
     (do
       (local forms
         (->> (config.get-in [:extract :form_pairs])

--- a/lua/conjure/eval.lua
+++ b/lua/conjure/eval.lua
@@ -166,7 +166,8 @@ local function current_form(extra_opts)
     local _let_19_ = form
     local content = _let_19_["content"]
     local range = _let_19_["range"]
-    eval_str(a.merge({code = content, range = range, origin = "current-form"}, extra_opts))
+    local node_type = _let_19_["node-type"]
+    eval_str(a.merge({code = content, range = range, ["node-type"] = node_type, origin = "current-form"}, extra_opts))
     return form
   else
     return nil
@@ -181,11 +182,12 @@ local function replace_form()
     local _let_21_ = form
     local content = _let_21_["content"]
     local range = _let_21_["range"]
+    local node_type = _let_21_["node-type"]
     local function _22_(result)
       buffer["replace-range"](buf, range, result)
       return editor["go-to"](win, a["get-in"](range, {"start", 1}), a.inc(a["get-in"](range, {"start", 2})))
     end
-    eval_str({code = content, range = range, origin = "replace-form", ["suppress-hud?"] = true, ["on-result"] = _22_})
+    eval_str({code = content, range = range, ["node-type"] = node_type, origin = "replace-form", ["suppress-hud?"] = true, ["on-result"] = _22_})
     return form
   else
     return nil
@@ -198,7 +200,8 @@ local function root_form()
     local _let_24_ = form
     local content = _let_24_["content"]
     local range = _let_24_["range"]
-    return eval_str({code = content, range = range, origin = "root-form"})
+    local node_type = _let_24_["node-type"]
+    return eval_str({code = content, range = range, ["node-type"] = node_type, origin = "root-form"})
   else
     return nil
   end

--- a/lua/conjure/extract.lua
+++ b/lua/conjure/extract.lua
@@ -150,7 +150,7 @@ local function form(opts)
       node = ts["get-form"]()
     end
     if node then
-      return {range = ts.range(node), content = ts["node->str"](node)}
+      return {range = ts.range(node), content = ts["node->str"](node), ["node-type"] = tostring(node)}
     else
       return nil
     end


### PR DESCRIPTION
As title. Currently client don't know the type of the node. With this PR, this can be resolved, and later we can add support for non-lisps base on this. 