### PR TITLE
fix(log): ensure state.hud.id is truthy before close-hud

### DIFF
--- a/fnl/conjure/log.fnl
+++ b/fnl/conjure/log.fnl
@@ -162,7 +162,8 @@
             (when (= 1 (nvim.fn.has "nvim-0.5"))
               {:border border}))]
 
-      (when (not (nvim.win_is_valid state.hud.id))
+      (when (and state.hud.id
+                 (not (nvim.win_is_valid state.hud.id)))
         (close-hud))
 
       (if state.hud.id

--- a/lua/conjure/log.lua
+++ b/lua/conjure/log.lua
@@ -189,7 +189,7 @@ local function display_hud()
       end
     end
     win_opts = a.merge({relative = "editor", row = pos.row, col = pos.col, anchor = pos.anchor, width = size.width, height = size.height, focusable = false, style = "minimal"}, _18_())
-    if not nvim.win_is_valid(state.hud.id) then
+    if (state.hud.id and not nvim.win_is_valid(state.hud.id)) then
       close_hud()
     else
     end


### PR DESCRIPTION
Latest nvim changes requires arguments to win_is_valid to be a number.
It cannot depend on nil being treated as 0 anymore.

Fixes #293