### PR TITLE
Raw printing in test mode

### DIFF
--- a/fnl/conjure/client/clojure/nrepl/ui.fnl
+++ b/fnl/conjure/client/clojure/nrepl/ui.fnl
@@ -28,8 +28,8 @@
         (text.prefixed-lines
           (text.trim-last-newline resp.out)
           (if
-            opts.simple-out? "; "
             (or opts.raw-out? (cfg [:eval :raw_out])) ""
+            opts.simple-out? "; "
             "; (out) ")
           {:skip-first? joined?})
 

--- a/lua/conjure/client/clojure/nrepl/ui.lua
+++ b/lua/conjure/client/clojure/nrepl/ui.lua
@@ -50,10 +50,10 @@ local function display_result(resp, opts)
   local _4_
   if resp.out then
     local _5_
-    if opts0["simple-out?"] then
-      _5_ = "; "
-    elseif (opts0["raw-out?"] or cfg({"eval", "raw_out"})) then
+    if (opts0["raw-out?"] or cfg({"eval", "raw_out"})) then
       _5_ = ""
+    elseif opts0["simple-out?"] then
+      _5_ = "; "
     else
       _5_ = "; (out) "
     end


### PR DESCRIPTION
Following https://github.com/Olical/conjure/pull/274.
Currently when set `let g:conjure#client#clojure#nrepl#test#raw_out = v:true` and run the tests, all output will be prefixed with a `;` this makes syntax highlight not working.

This PR removes that `;`.
Before
![Screen Shot 2022-02-06 at 16 28 00](https://user-images.githubusercontent.com/25661381/152674874-e8696385-3483-4e59-8711-3d622f07408e.png)

After
![Screen Shot 2022-02-06 at 16 28 39](https://user-images.githubusercontent.com/25661381/152674877-163235b4-565c-4f16-a655-fd75aee32827.png)