### PR TITLE
Check for each nREPL port file at each tree level (#317)

### DIFF
--- a/fnl/conjure/client/clojure/nrepl/action.fnl
+++ b/fnl/conjure/client/clojure/nrepl/action.fnl
@@ -65,7 +65,7 @@
 (defn connect-port-file [opts]
   (let [resolved
         (-?>> (cfg [:connection :port_files])
-              (a.map fs.resolve-above)
+              (fs.resolve-above)
               (a.some
                 (fn [path]
                   (let [port (a.slurp path)]

--- a/fnl/conjure/fs.fnl
+++ b/fnl/conjure/fs.fnl
@@ -25,14 +25,44 @@
     (when (not (a.empty? res))
       res)))
 
-(defn resolve-above [name]
+(defn parent-dir [path]
+  (let [res (-> path
+                (split-path)
+                (a.butlast)
+                (join-path))]
+    (if (= "" res)
+      nil
+      ;; TODO: Needs to be Windows compatible?
+      (.. "/" res))))
+
+(defn upwards-file-search [orig-names orig-dir]
+  "Given a list of relative filenames and an absolute path to a directory,
+  return the absolute path of the first file that matches a relative path,
+  starting at the directory and then upwards towards the root directory. If no
+  match is found, return nil."
+  (var names orig-names)
+  (var dir orig-dir)
+  (var file nil)
+  (while (and dir (not file))
+    (let [name (a.first names)]
+      (if name
+        (let [res (findfile name dir)]
+          (if res
+            (set file res)
+            (set names (a.rest names))))
+        (do
+          (set names orig-names)
+          (set dir (parent-dir dir))))))
+  file)
+
+(defn resolve-above [names]
   "Resolve a pathless file name to an absolute path by looking in the
   containing and parent directories of the current file, current working
-  direcotry and finally $XDG_CONFIG_HOME/conjure"
+  directory and finally $XDG_CONFIG_HOME/conjure"
   (or
-    (findfile name ".;")
-    (findfile name (.. (nvim.fn.getcwd) ";"))
-    (findfile name (.. (config-dir) ";"))))
+    (upwards-file-search names (nvim.fn.expand "%:p:h"))
+    (upwards-file-search names (nvim.fn.getcwd))
+    (upwards-file-search names (config-dir))))
 
 (defn file-readable? [path]
   (= 1 (nvim.fn.filereadable path)))


### PR DESCRIPTION
Fixes #317

Hi there Ollie! I'm trying to make my first Conjure contribution and I took a crack at this issue. This isn't ready for merging at all but I wanted to show you that I'm working on it. ~~I still need to get my nvim fennel setup functional and I haven't run any tests yet.~~

~~The change I made is basically so that `resolve-above` now takes a list of filenames and also has a 2-arity version that accepts a path. This path is expected to be a directory without a trailing slash which I believe is compatible with the current code. Then it goes up each level of the path hierarchy and searches for the nrepl files with the `findfiles` function already in place.~~

~~The surprisingly tricky bit is getting the parent directory from a path string since we can't use `vim.fn.findfile`'s upward searching functionality anymore. We could upwardly search for each nREPL file and then compare the depth of each match but that is probably less efficient. I added the `parent-dir` function which uses Lua's pattern matching to get the parent directory from a string. I couldn't find any neovim builtin that could do this and that was pretty surprising. Maybe there's a better way? I'm no (neo)vim API expert.~~

~~The `parent-dir` function takes a filepath separator string which should be dependent on the host OS so there needs to be a check for Windows but I'm not sure how.~~

Feel free to suggest something totally different than what I have here! Happy to change it all up.