### PR TITLE
[WIP] Refactor and improve Common Lisp client

### DIFF
--- a/fnl/conjure/client/common-lisp/swank.fnl
+++ b/fnl/conjure/client/common-lisp/swank.fnl
@@ -3,6 +3,7 @@
              nvim conjure.aniseed.nvim
              bridge conjure.bridge
              mapping conjure.mapping
+             utils conjure.client.common-lisp.utils
              text conjure.text
              log conjure.log
              str conjure.aniseed.string
@@ -61,16 +62,31 @@
       (display-conn-status :disconnected)
       (a.assoc (state) :conn nil))))
 
-(defn- escape-string [in]
-  "puts leading slashes infront of \\ and \"
-  so that swank can correctly interpret the results."
-  (fn replace [in pat rep]
-    (let [(s c) (string.gsub in pat rep)] s))
-  (-> in
-      (replace "\\" "\\\\")
-      (replace "\"" "\\\"")))
+(defn eval-str [opts]
+  "With the given string, send it to swank/slynk to evaluate"
+  " and parse the results"
+  (try-ensure-conn)
+
+  (when (not (a.empty? opts.code))
+    (send
+      opts.code
+      (when (not (a.empty? opts.context))
+        opts.context)
+      (fn [msg]
+        ;; parse response from swank and split into stdout/result
+        (let [(stdout result) (utils.parse-result msg)]
+          (utils.display-stdout stdout)
+          (when (not= nil result)
+            (when opts.on-result
+              (opts.on-result result))
+
+            (when (not opts.passive?)
+              (log.append (text.split-lines result)))))))))
 
 (defn- send [msg context cb]
+  "Send a message with the given context and call `cb` on the response"
+  ;; TODO should this be living in the transport layer? as it is 
+  ;; something specific to what transport we're using. ( swank / slynk / other)
   (with-conn-or-warn
     (fn [conn]
       (let [eval-id (a.get (a.update (state) :eval-id a.inc) :eval-id)]
@@ -80,8 +96,10 @@
         (remote.send
           conn
           (str.join
+            ;; TODO: This code should be changed to ideally send various messages
+            ;; if need by by slynk/swank
             ["(:emacs-rex (swank:eval-and-grab-output \""
-             (escape-string msg)
+             (utils.escape-string msg)
              "\") \"" (or context ":common-lisp-user") "\" t " eval-id ")"])
           cb)))))
 
@@ -119,137 +137,6 @@
 (defn- try-ensure-conn []
   (when (not (connected?))
     (connect {:silent? true})))
-
-(defn- string-stream [str]
-  "Convert a string into a byte-value iterator"
-  (var index 1)
-  (fn []
-    (let [r (str:byte index)]
-      (set index (+ index 1))
-      r)))
-
-(defn- display-stdout [msg]
-  (when (and (not= nil msg) (not= "" msg))
-    (log.append (text.prefixed-lines msg comment-prefix))))
-
-
-(defn- inner-results [received]
-  "A string of '(:return (:ok (blah)) 1)' should just give us the blah"
-  ;; this is super hacky, but it seems to work, so we're going with it
-  ;; until something better comes along.
-  (local search-string "(:return (:ok (")
-  (local tail-size 5) ;; TODO: once we fix up the increments, this will change
-  (let [(idx len) (string.find received search-string 1 true)]
-    (string.sub received
-                (+ idx len)
-                (- (string.len received) tail-size))))
-
-(defn- parse-separated-list [string-to-parse]
-  "Take a string of quoted components and return an array of those values,
-  ie: (I'm using single instead of double quotes in the example for ease)
-
-  'this is' not the 'the\' output'
-  => ['this is' 'the\' output'] (length of 2)
-
-  We must be able to correctly deal with escaped values.
-  This is the form that SWANK gives us, along the lines of:
-      (:return (:ok ('stdout-things' 'results-of-eval')) 1)
-  "
-  ;; (parse-separated-list " \"hello\" to the \"\\\"world\\\"\" ")
-  ;; expected value [ "hello" "\"world\""]
-
-  (var opened-quote nil)
-  (var escaped false)
-  (var stack [])
-  (var vals [])
-
-  (local slash-byte (string.byte "\\"))
-  (local quote-byte (string.byte "\""))
-
-  (fn maybe-insert [b]
-    "insert the value, and reset the escape flag"
-    (when opened-quote
-      (table.insert stack b)
-      (set escaped false)))
-
-  (fn maybe-close [b]
-    "When we reach a quote, we could be starting/stopping
-    a value, or we could have escaped this byte, etc"
-    (if opened-quote
-      (do
-        (when (not escaped)
-          ; move the entire stack into vals and clear
-          (set opened-quote false)
-          (table.insert
-            vals
-            (string.char
-              (unpack stack)))
-          (set stack []))
-        (when escaped
-          ;; if we've escaped this quote, put it in.
-          (maybe-insert b)))
-      (do
-        (when escaped
-          (log.dbg "Received an escaped quote outside of expected values"))
-        (set opened-quote true))))
-
-  (fn slash-escape [b]
-    "process a \\ value, which could be escaped or escaping something else"
-    (if escaped
-      (maybe-insert b)
-      (set escaped true)))
-
-  (fn dispatch [b]
-    "process each byte that comes in"
-    (match b
-      slash-byte (slash-escape b)
-      quote-byte (maybe-close b)
-      _ (maybe-insert b)))
-
-  (each [b (string-stream string-to-parse)]
-    (dispatch b))
-  ;;finally return vals
-  vals)
-
-(defn parse-result [received]
-  "Given the form (:return (:ok (\"\" \"(1 2 \\\"3\\\" 4)\")) 1) we want)])
-  to extract both
-  - the stdout, which is the first delimited quoted component
-  - the result, which is the second delimited quoted component
-
-  If there has been an error, it will not look like a result, so more parsing
-  will be needed"
-  (fn result? [response]
-    (text.starts-with response "(:return (:ok ("))
-
-  ;; TODO - parse debug messages properly and show them in a nice way
-  ;; I'm not sure what the proper conjure way is here.
-  (when (not (result? received))
-    ;;super hack; taking out the first quoted component and hoping it is
-    ;; a nice message.
-    (let [(msg) (pick-values 1 (parse-separated-list received))]
-      (display-stdout (. msg 1))))
-
-  (when (result? received)
-    (unpack (parse-separated-list (inner-results received)))))
-
-(defn eval-str [opts]
-  (try-ensure-conn)
-
-  (when (not (a.empty? opts.code))
-    (send
-      opts.code
-      (when (not (a.empty? opts.context))
-        opts.context)
-      (fn [msg]
-        (let [(stdout result) (parse-result msg)]
-          (display-stdout stdout)
-          (when (not= nil result)
-            (when opts.on-result
-              (opts.on-result result))
-
-            (when (not opts.passive?)
-              (log.append (text.split-lines result)))))))))
 
 (defn doc-str [opts]
   (try-ensure-conn)

--- a/fnl/conjure/client/common-lisp/utils.fnl
+++ b/fnl/conjure/client/common-lisp/utils.fnl
@@ -1,0 +1,139 @@
+(module conjure.client.common-lisp.utils
+  {autoload {a conjure.aniseed.core
+             nvim conjure.aniseed.nvim
+             bridge conjure.bridge
+             mapping conjure.mapping
+             text conjure.text
+             log conjure.log
+             str conjure.aniseed.string
+             config conjure.config
+             client conjure.client
+             remote conjure.remote.swank}})
+
+;;;; Common-lisp parser-utils
+;;;; various functions mainly dealing with parsing the
+;;;; string messages from swank/slynk into proper common
+;;;; lisp forms.
+
+(defn- string-stream [str]
+  "Convert a string into a byte-value iterator"
+  (var index 1)
+  (fn []
+    (let [r (str:byte index)]
+      (set index (+ index 1))
+      r)))
+
+(defn- display-stdout [msg]
+  "Displays the given `msg` on the log with comment-prefix"
+  (when (and (not= nil msg) (not= "" msg))
+    (log.append (text.prefixed-lines msg comment-prefix))))
+
+
+(defn- inner-results [received]
+  "A string of '(:return (:ok (blah)) 1)' should just give us the blah"
+  ;; this is super hacky, but it seems to work, so we're going with it
+  ;; until something better comes along.
+
+  ;; TODO don't do this:
+  (local search-string "(:return (:ok (")
+  (local tail-size 5) ;; TODO: once we fix up the increments, this will change
+  (let [(idx len) (string.find received search-string 1 true)]
+    (string.sub received
+                (+ idx len)
+                (- (string.len received) tail-size))))
+
+(defn- parse-separated-list [string-to-parse]
+  "Take a string of quoted components and return an array of those values,
+  ie: (I'm using single instead of double quotes in the example for ease)
+
+  'this is' not the 'the\' output'
+  => ['this is' 'the\' output'] (length of 2)
+
+  We must be able to correctly deal with escaped values.
+  This is the form that SWANK gives us, along the lines of:
+      (:return (:ok ('stdout-things' 'results-of-eval')) 1)
+  "
+  (var opened-quote nil)
+  (var escaped false)
+  (var stack [])
+  (var vals [])
+
+  (local slash-byte (string.byte "\\"))
+  (local quote-byte (string.byte "\""))
+
+  (fn maybe-insert [b]
+    "insert the value, and reset the escape flag"
+    (when opened-quote
+      (table.insert stack b)
+      (set escaped false)))
+
+  (fn maybe-close [b]
+    "When we reach a quote, we could be starting/stopping
+    a value, or we could have escaped this byte, etc"
+    (if opened-quote
+      (do
+        (when (not escaped)
+          ; move the entire stack into vals and clear
+          (set opened-quote false)
+          (table.insert
+            vals
+            (string.char
+              (unpack stack)))
+          (set stack []))
+        (when escaped
+          ;; if we've escaped this quote, put it in.
+          (maybe-insert b)))
+      (do
+        (when escaped
+          (log.dbg "Received an escaped quote outside of expected values"))
+        (set opened-quote true))))
+
+  (fn slash-escape [b]
+    "process a \\ value, which could be escaped or escaping something else"
+    (if escaped
+      (maybe-insert b)
+      (set escaped true)))
+
+  (fn dispatch [b]
+    "process each byte that comes in"
+    (match b
+      slash-byte (slash-escape b)
+      quote-byte (maybe-close b)
+      _ (maybe-insert b)))
+
+  (each [b (string-stream string-to-parse)]
+    (dispatch b))
+  ;;finally return vals
+  vals)
+
+(defn parse-result [received]
+  "Given the form  :return  :ok  \"\" \"(1 2 \\\"3\\\" 4)\")) 1) we want)])
+  to extract both
+  - the stdout, which is the first delimited quoted component
+  - the result, which is the second delimited quoted component
+
+  If there has been an error, it will not look like a result, so more parsing
+  will be needed"
+  (fn result? [response]
+    (text.starts-with response "(:return (:ok ("))
+
+  ;; TODO - parse debug messages properly and show them in a nice way
+  ;; I'm not sure what the proper conjure way is here.
+  (when (not (result? received))
+    ;;super hack; taking out the first quoted component and hoping it is
+    ;; a nice message.
+    (let [(msg) (pick-values 1 (parse-separated-list received))]
+      (display-stdout (. msg 1))))
+
+  (when (result? received)
+    (unpack (parse-separated-list (inner-results received)))))
+
+
+(defn- escape-string [in]
+  "puts leading slashes infront of \\ and \"
+  so that swank can correctly interpret the results."
+  (fn replace [in pat rep]
+    (let [(s c) (string.gsub in pat rep)] s))
+  (-> in
+      (replace "\\" "\\\\")
+      (replace "\"" "\\\"")))

--- a/fnl/conjure/remote/slynk.fnl
+++ b/fnl/conjure/remote/slynk.fnl
@@ -1,0 +1,64 @@
+(module conjure.remote.swank
+  {autoload {a conjure.aniseed.core
+             net conjure.net
+             log conjure.log
+             client conjure.client
+             trn conjure.remote.transport.slynk
+             nvim conjure.aniseed.nvim}})
+
+;;;; Slynk Transport layer for common lisp
+;;;; This module should focus on interactions in the 
+;;;; transport layer for slynk, such as connecting
+;;;; and sending messages.
+
+(defn send [conn msg cb]
+  "Send `msg` to the connection `conn` and call `cb` with the result."
+  (table.insert conn.queue 1 (or cb false))
+  ;; Note that we encode using conjure.remote.transport.slynk
+  (conn.sock:write (trn.encode msg))
+  nil)
+
+(defn connect [opts]
+  "Connects to a remote slynk server.
+  * opts.host: The host string.
+  * opts.port: Port as a string.
+  * opts.name: Name of the client to send post-connection, defaults to `Conjure`.
+  * opts.on-failure: Function to call after a failed connection with the error.
+  * opts.on-success: Function to call on a successful connection.
+  * opts.on-error: Function to call when we receive an error (passed as argument) or a nil response.
+  Returns a connection table containing a `destroy` function."
+
+  (var conn
+    {:decode trn.decode
+     :queue []})
+
+  (fn handle-message [err chunk]
+    (if (or err (not chunk))
+      (opts.on-error err)
+      (->> (conn.decode chunk)
+           ((fn [msg]
+              (log.dbg "receive" msg)
+              (let [cb (table.remove conn.queue)]
+                (when cb
+                  (cb msg))))))))
+
+  (set conn
+       (a.merge
+         conn
+         (net.connect
+           {:host opts.host
+            :port opts.port
+            :cb (client.schedule-wrap
+                  (fn [err]
+                    (if err
+                      (opts.on-failure err)
+
+                      (do
+                        (conn.sock:read_start (client.schedule-wrap handle-message))
+                        (opts.on-success)))))})))
+
+  ;; any post-connect commands should be sent here, such as reporting features and 
+  ;; setting options.
+  ; (send conn (or opts.name "Conjure"))
+  conn)
+

--- a/fnl/conjure/remote/transport/slynk.fnl
+++ b/fnl/conjure/remote/transport/slynk.fnl
@@ -1,0 +1,27 @@
+(module conjure.remote.transport.swank
+  {autoload {a conjure.aniseed.core
+             log conjure.log}})
+
+;;;; Slynk transport layer to deal with message encoding and decoding.
+;;;; For reference, these functions should generally match what is expected
+;;;; here: https://github.com/joaotavora/sly/blob/master/slynk/slynk-rpc.lisp#L150
+;;;; (look for "write-message" and others in slynk rpc) 
+
+(defn encode [msg]
+  "Slynk RPC encoding"
+  ;; TODO currently this is swank encoding, which might be similar
+  ;; to what is expected by slynk, but will need to be verified.
+  ;; we currently write out 6 hexidecimal digits to signify length before 
+  ;; we send out our messge.
+  (let [n (a.count msg)
+        header (string.format "%06x" (+ 1 n))] ; Additional 1 for trailing newline
+    (.. header msg "\n")))
+
+(defn decode [msg]
+  "Slynk RPC decoding"
+  ;; read length for the first 6 digits, and then trim
+  ;; the string for that length.
+  ;; note that this matches the above.
+  (let [len (tonumber (string.sub msg 1 7) 16)
+        cmd (string.sub msg 7 len)]
+    cmd))

--- a/lua/conjure/client/common-lisp/swank.lua
+++ b/lua/conjure/client/common-lisp/swank.lua
@@ -11,7 +11,7 @@ do
   _2amodule_locals_2a = (_2amodule_2a)["aniseed/locals"]
 end
 local autoload = (require("conjure.aniseed.autoload")).autoload
-local a, bridge, client, config, log, mapping, nvim, remote, str, text, ts = autoload("conjure.aniseed.core"), autoload("conjure.bridge"), autoload("conjure.client"), autoload("conjure.config"), autoload("conjure.log"), autoload("conjure.mapping"), autoload("conjure.aniseed.nvim"), autoload("conjure.remote.swank"), autoload("conjure.aniseed.string"), autoload("conjure.text"), autoload("conjure.tree-sitter")
+local a, bridge, client, config, log, mapping, nvim, remote, str, text, ts, utils = autoload("conjure.aniseed.core"), autoload("conjure.bridge"), autoload("conjure.client"), autoload("conjure.config"), autoload("conjure.log"), autoload("conjure.mapping"), autoload("conjure.aniseed.nvim"), autoload("conjure.remote.swank"), autoload("conjure.aniseed.string"), autoload("conjure.text"), autoload("conjure.tree-sitter"), autoload("conjure.client.common-lisp.utils")
 do end (_2amodule_locals_2a)["a"] = a
 _2amodule_locals_2a["bridge"] = bridge
 _2amodule_locals_2a["client"] = client
@@ -23,6 +23,7 @@ _2amodule_locals_2a["remote"] = remote
 _2amodule_locals_2a["str"] = str
 _2amodule_locals_2a["text"] = text
 _2amodule_locals_2a["ts"] = ts
+_2amodule_locals_2a["utils"] = utils
 local buf_suffix = ".lisp"
 _2amodule_2a["buf-suffix"] = buf_suffix
 local context_pattern = "%(%s*defpackage%s+(.-)[%s){]"
@@ -71,180 +72,18 @@ local function disconnect()
   return with_conn_or_warn(_5_)
 end
 _2amodule_2a["disconnect"] = disconnect
-local function escape_string(_in)
-  local function replace(_in0, pat, rep)
-    local s, c = string.gsub(_in0, pat, rep)
-    return s
-  end
-  return replace(replace(_in, "\\", "\\\\"), "\"", "\\\"")
-end
-_2amodule_locals_2a["escape-string"] = escape_string
-local function send(msg, context, cb)
-  local function _6_(conn)
-    local eval_id = a.get(a.update(state(), "eval-id", a.inc), "eval-id")
-    return remote.send(conn, str.join({"(:emacs-rex (swank:eval-and-grab-output \"", escape_string(msg), "\") \"", (context or ":common-lisp-user"), "\" t ", eval_id, ")"}), cb)
-  end
-  return with_conn_or_warn(_6_)
-end
-_2amodule_locals_2a["send"] = send
-local function connect(opts)
-  local opts0 = (opts or {})
-  local host = (opts0.host or config["get-in"]({"client", "common_lisp", "swank", "connection", "default_host"}))
-  local port = (opts0.port or config["get-in"]({"client", "common_lisp", "swank", "connection", "default_port"}))
-  if state("conn") then
-    disconnect()
-  else
-  end
-  local function _8_(err)
-    display_conn_status(err)
-    return disconnect()
-  end
-  local function _9_()
-    return display_conn_status("connected")
-  end
-  local function _10_(err)
-    if err then
-      return display_conn_status(err)
-    else
-      return disconnect()
-    end
-  end
-  a.assoc(state(), "conn", remote.connect({host = host, port = port, ["on-failure"] = _8_, ["on-success"] = _9_, ["on-error"] = _10_}))
-  local function _12_(_)
-  end
-  return send(":ok", _12_)
-end
-_2amodule_2a["connect"] = connect
-local function try_ensure_conn()
-  if not connected_3f() then
-    return connect({["silent?"] = true})
-  else
-    return nil
-  end
-end
-_2amodule_locals_2a["try-ensure-conn"] = try_ensure_conn
-local function string_stream(str0)
-  local index = 1
-  local function _14_()
-    local r = str0:byte(index)
-    index = (index + 1)
-    return r
-  end
-  return _14_
-end
-_2amodule_locals_2a["string-stream"] = string_stream
-local function display_stdout(msg)
-  if ((nil ~= msg) and ("" ~= msg)) then
-    return log.append(text["prefixed-lines"](msg, comment_prefix))
-  else
-    return nil
-  end
-end
-_2amodule_locals_2a["display-stdout"] = display_stdout
-local function inner_results(received)
-  local search_string = "(:return (:ok ("
-  local tail_size = 5
-  local idx, len = string.find(received, search_string, 1, true)
-  return string.sub(received, (idx + len), (string.len(received) - tail_size))
-end
-_2amodule_locals_2a["inner-results"] = inner_results
-local function parse_separated_list(string_to_parse)
-  local opened_quote = nil
-  local escaped = false
-  local stack = {}
-  local vals = {}
-  local slash_byte = string.byte("\\")
-  local quote_byte = string.byte("\"")
-  local function maybe_insert(b)
-    if opened_quote then
-      table.insert(stack, b)
-      escaped = false
-      return nil
-    else
-      return nil
-    end
-  end
-  local function maybe_close(b)
-    if opened_quote then
-      if not escaped then
-        opened_quote = false
-        table.insert(vals, string.char(unpack(stack)))
-        stack = {}
-      else
-      end
-      if escaped then
-        return maybe_insert(b)
-      else
-        return nil
-      end
-    else
-      if escaped then
-        log.dbg("Received an escaped quote outside of expected values")
-      else
-      end
-      opened_quote = true
-      return nil
-    end
-  end
-  local function slash_escape(b)
-    if escaped then
-      return maybe_insert(b)
-    else
-      escaped = true
-      return nil
-    end
-  end
-  local function dispatch(b)
-    local _22_ = b
-    if (_22_ == slash_byte) then
-      return slash_escape(b)
-    elseif (_22_ == quote_byte) then
-      return maybe_close(b)
-    elseif true then
-      local _ = _22_
-      return maybe_insert(b)
-    else
-      return nil
-    end
-  end
-  for b in string_stream(string_to_parse) do
-    dispatch(b)
-  end
-  return vals
-end
-_2amodule_locals_2a["parse-separated-list"] = parse_separated_list
-local function parse_result(received)
-  local function result_3f(response)
-    return text["starts-with"](response, "(:return (:ok (")
-  end
-  if not result_3f(received) then
-    local msg
-    do
-      local _24_ = parse_separated_list(received)
-      msg = _24_
-    end
-    display_stdout(msg[1])
-  else
-  end
-  if result_3f(received) then
-    return unpack(parse_separated_list(inner_results(received)))
-  else
-    return nil
-  end
-end
-_2amodule_2a["parse-result"] = parse_result
 local function eval_str(opts)
-  try_ensure_conn()
+  __fnl_global__try_2densure_2dconn()
   if not a["empty?"](opts.code) then
-    local _27_
+    local _6_
     if not a["empty?"](opts.context) then
-      _27_ = opts.context
+      _6_ = opts.context
     else
-      _27_ = nil
+      _6_ = nil
     end
-    local function _29_(msg)
-      local stdout, result = parse_result(msg)
-      display_stdout(stdout)
+    local function _8_(msg)
+      local stdout, result = utils["parse-result"](msg)
+      utils["display-stdout"](stdout)
       if (nil ~= result) then
         if opts["on-result"] then
           opts["on-result"](result)
@@ -259,18 +98,62 @@ local function eval_str(opts)
         return nil
       end
     end
-    return send(opts.code, _27_, _29_)
+    return send(opts.code, _6_, _8_)
   else
     return nil
   end
 end
 _2amodule_2a["eval-str"] = eval_str
+local function send(msg, context, cb)
+  local function _13_(conn)
+    local eval_id = a.get(a.update(state(), "eval-id", a.inc), "eval-id")
+    return remote.send(conn, str.join({"(:emacs-rex (swank:eval-and-grab-output \"", utils["escape-string"](msg), "\") \"", (context or ":common-lisp-user"), "\" t ", eval_id, ")"}), cb)
+  end
+  return with_conn_or_warn(_13_)
+end
+_2amodule_locals_2a["send"] = send
+local function connect(opts)
+  local opts0 = (opts or {})
+  local host = (opts0.host or config["get-in"]({"client", "common_lisp", "swank", "connection", "default_host"}))
+  local port = (opts0.port or config["get-in"]({"client", "common_lisp", "swank", "connection", "default_port"}))
+  if state("conn") then
+    disconnect()
+  else
+  end
+  local function _15_(err)
+    display_conn_status(err)
+    return disconnect()
+  end
+  local function _16_()
+    return display_conn_status("connected")
+  end
+  local function _17_(err)
+    if err then
+      return display_conn_status(err)
+    else
+      return disconnect()
+    end
+  end
+  a.assoc(state(), "conn", remote.connect({host = host, port = port, ["on-failure"] = _15_, ["on-success"] = _16_, ["on-error"] = _17_}))
+  local function _19_(_)
+  end
+  return send(":ok", _19_)
+end
+_2amodule_2a["connect"] = connect
+local function try_ensure_conn()
+  if not connected_3f() then
+    return connect({["silent?"] = true})
+  else
+    return nil
+  end
+end
+_2amodule_locals_2a["try-ensure-conn"] = try_ensure_conn
 local function doc_str(opts)
   try_ensure_conn()
-  local function _34_(_241)
+  local function _21_(_241)
     return ("(describe #'" .. _241 .. ")")
   end
-  return eval_str(a.update(opts, "code", _34_))
+  return eval_str(a.update(opts, "code", _21_))
 end
 _2amodule_2a["doc-str"] = doc_str
 local function eval_file(opts)

--- a/lua/conjure/client/common-lisp/utils.lua
+++ b/lua/conjure/client/common-lisp/utils.lua
@@ -1,0 +1,143 @@
+local _2afile_2a = "fnl/conjure/client/common-lisp/utils.fnl"
+local _2amodule_name_2a = "conjure.client.common-lisp.utils"
+local _2amodule_2a
+do
+  package.loaded[_2amodule_name_2a] = {}
+  _2amodule_2a = package.loaded[_2amodule_name_2a]
+end
+local _2amodule_locals_2a
+do
+  _2amodule_2a["aniseed/locals"] = {}
+  _2amodule_locals_2a = (_2amodule_2a)["aniseed/locals"]
+end
+local autoload = (require("conjure.aniseed.autoload")).autoload
+local a, bridge, client, config, log, mapping, nvim, remote, str, text = autoload("conjure.aniseed.core"), autoload("conjure.bridge"), autoload("conjure.client"), autoload("conjure.config"), autoload("conjure.log"), autoload("conjure.mapping"), autoload("conjure.aniseed.nvim"), autoload("conjure.remote.swank"), autoload("conjure.aniseed.string"), autoload("conjure.text")
+do end (_2amodule_locals_2a)["a"] = a
+_2amodule_locals_2a["bridge"] = bridge
+_2amodule_locals_2a["client"] = client
+_2amodule_locals_2a["config"] = config
+_2amodule_locals_2a["log"] = log
+_2amodule_locals_2a["mapping"] = mapping
+_2amodule_locals_2a["nvim"] = nvim
+_2amodule_locals_2a["remote"] = remote
+_2amodule_locals_2a["str"] = str
+_2amodule_locals_2a["text"] = text
+local function string_stream(str0)
+  local index = 1
+  local function _1_()
+    local r = str0:byte(index)
+    index = (index + 1)
+    return r
+  end
+  return _1_
+end
+_2amodule_locals_2a["string-stream"] = string_stream
+local function display_stdout(msg)
+  if ((nil ~= msg) and ("" ~= msg)) then
+    return log.append(text["prefixed-lines"](msg, __fnl_global__comment_2dprefix))
+  else
+    return nil
+  end
+end
+_2amodule_locals_2a["display-stdout"] = display_stdout
+local function inner_results(received)
+  local search_string = "(:return (:ok ("
+  local tail_size = 5
+  local idx, len = string.find(received, search_string, 1, true)
+  return string.sub(received, (idx + len), (string.len(received) - tail_size))
+end
+_2amodule_locals_2a["inner-results"] = inner_results
+local function parse_separated_list(string_to_parse)
+  local opened_quote = nil
+  local escaped = false
+  local stack = {}
+  local vals = {}
+  local slash_byte = string.byte("\\")
+  local quote_byte = string.byte("\"")
+  local function maybe_insert(b)
+    if opened_quote then
+      table.insert(stack, b)
+      escaped = false
+      return nil
+    else
+      return nil
+    end
+  end
+  local function maybe_close(b)
+    if opened_quote then
+      if not escaped then
+        opened_quote = false
+        table.insert(vals, string.char(unpack(stack)))
+        stack = {}
+      else
+      end
+      if escaped then
+        return maybe_insert(b)
+      else
+        return nil
+      end
+    else
+      if escaped then
+        log.dbg("Received an escaped quote outside of expected values")
+      else
+      end
+      opened_quote = true
+      return nil
+    end
+  end
+  local function slash_escape(b)
+    if escaped then
+      return maybe_insert(b)
+    else
+      escaped = true
+      return nil
+    end
+  end
+  local function dispatch(b)
+    local _9_ = b
+    if (_9_ == slash_byte) then
+      return slash_escape(b)
+    elseif (_9_ == quote_byte) then
+      return maybe_close(b)
+    elseif true then
+      local _ = _9_
+      return maybe_insert(b)
+    else
+      return nil
+    end
+  end
+  for b in string_stream(string_to_parse) do
+    dispatch(b)
+  end
+  return vals
+end
+_2amodule_locals_2a["parse-separated-list"] = parse_separated_list
+local function parse_result(received)
+  local function result_3f(response)
+    return text["starts-with"](response, "(:return (:ok (")
+  end
+  if not result_3f(received) then
+    local msg
+    do
+      local _11_ = parse_separated_list(received)
+      msg = _11_
+    end
+    display_stdout(msg[1])
+  else
+  end
+  if result_3f(received) then
+    return unpack(parse_separated_list(inner_results(received)))
+  else
+    return nil
+  end
+end
+_2amodule_2a["parse-result"] = parse_result
+local function escape_string(_in)
+  local function replace(_in0, pat, rep)
+    local s, c = string.gsub(_in0, pat, rep)
+    return s
+  end
+  return replace(replace(_in, "\\", "\\\\"), "\"", "\\\"")
+end
+_2amodule_locals_2a["escape-string"] = escape_string
+return _2amodule_2a

--- a/lua/conjure/remote/slynk.lua
+++ b/lua/conjure/remote/slynk.lua
@@ -1,0 +1,57 @@
+local _2afile_2a = "fnl/conjure/remote/slynk.fnl"
+local _2amodule_name_2a = "conjure.remote.swank"
+local _2amodule_2a
+do
+  package.loaded[_2amodule_name_2a] = {}
+  _2amodule_2a = package.loaded[_2amodule_name_2a]
+end
+local _2amodule_locals_2a
+do
+  _2amodule_2a["aniseed/locals"] = {}
+  _2amodule_locals_2a = (_2amodule_2a)["aniseed/locals"]
+end
+local autoload = (require("conjure.aniseed.autoload")).autoload
+local a, client, log, net, nvim, trn = autoload("conjure.aniseed.core"), autoload("conjure.client"), autoload("conjure.log"), autoload("conjure.net"), autoload("conjure.aniseed.nvim"), autoload("conjure.remote.transport.slynk")
+do end (_2amodule_locals_2a)["a"] = a
+_2amodule_locals_2a["client"] = client
+_2amodule_locals_2a["log"] = log
+_2amodule_locals_2a["net"] = net
+_2amodule_locals_2a["nvim"] = nvim
+_2amodule_locals_2a["trn"] = trn
+local function send(conn, msg, cb)
+  table.insert(conn.queue, 1, (cb or false))
+  do end (conn.sock):write(trn.encode(msg))
+  return nil
+end
+_2amodule_2a["send"] = send
+local function connect(opts)
+  local conn = {decode = trn.decode, queue = {}}
+  local function handle_message(err, chunk)
+    if (err or not chunk) then
+      return opts["on-error"](err)
+    else
+      local function _1_(msg)
+        log.dbg("receive", msg)
+        local cb = table.remove(conn.queue)
+        if cb then
+          return cb(msg)
+        else
+          return nil
+        end
+      end
+      return _1_(conn.decode(chunk))
+    end
+  end
+  local function _4_(err)
+    if err then
+      return opts["on-failure"](err)
+    else
+      do end (conn.sock):read_start(client["schedule-wrap"](handle_message))
+      return opts["on-success"]()
+    end
+  end
+  conn = a.merge(conn, net.connect({host = opts.host, port = opts.port, cb = client["schedule-wrap"](_4_)}))
+  return conn
+end
+_2amodule_2a["connect"] = connect
+return _2amodule_2a

--- a/lua/conjure/remote/transport/slynk.lua
+++ b/lua/conjure/remote/transport/slynk.lua
@@ -1,0 +1,29 @@
+local _2afile_2a = "fnl/conjure/remote/transport/slynk.fnl"
+local _2amodule_name_2a = "conjure.remote.transport.swank"
+local _2amodule_2a
+do
+  package.loaded[_2amodule_name_2a] = {}
+  _2amodule_2a = package.loaded[_2amodule_name_2a]
+end
+local _2amodule_locals_2a
+do
+  _2amodule_2a["aniseed/locals"] = {}
+  _2amodule_locals_2a = (_2amodule_2a)["aniseed/locals"]
+end
+local autoload = (require("conjure.aniseed.autoload")).autoload
+local a, log = autoload("conjure.aniseed.core"), autoload("conjure.log")
+do end (_2amodule_locals_2a)["a"] = a
+_2amodule_locals_2a["log"] = log
+local function encode(msg)
+  local n = a.count(msg)
+  local header = string.format("%06x", (1 + n))
+  return (header .. msg .. "\n")
+end
+_2amodule_2a["encode"] = encode
+local function decode(msg)
+  local len = tonumber(string.sub(msg, 1, 7), 16)
+  local cmd = string.sub(msg, 7, len)
+  return cmd
+end
+_2amodule_2a["decode"] = decode
+return _2amodule_2a


### PR DESCRIPTION
This PR is to improve the Common Lisp client, mainly by refactoring the code and making it easier to read, and changing to the `slynk` client that is a more modern and maintained version of `slime` for common lisp.

# TODO:
- [ ] Confirm Slynk message encoding/decoding in `remote.transport.slynk`
- [x] Refactor out utility functions into `common-lisp.utils`
- [ ] Connect Common Lisp Client to slynk transport
- [ ] Have helper / install script in wiki page _ie: a one-liner to quickstart_
- [ ] Remove `swank`-y code.
- [ ] General tidy up before merging.