### PR TITLE
Guile: Ensure that module is set before evaluation

### DIFF
--- a/fnl/conjure/client/guile/socket.fnl
+++ b/fnl/conjure/client/guile/socket.fnl
@@ -61,10 +61,15 @@
     (when (not (str.blank? clean))
       clean)))
 
+(defn- ctx-or-default [str]
+  (if str
+    str
+    "(guile-user)"))
+
 (defn eval-str [opts]
   (with-repl-or-warn
     (fn [repl]
-      (-?> opts.code
+      (-?> (.. ",m " (ctx-or-default opts.context) "\n" opts.code)
            (clean-input-code)
            (repl.send
              (fn [msgs]
@@ -121,14 +126,6 @@
        :error? false
        :result s})))
 
-(defn enter []
-  (let [repl (state :repl)
-        c (extract.context)]
-    (when (and repl (= :connected repl.status))
-      (repl.send
-        (.. ",m " (or c "(guile-user)") "\n")
-        (fn [])))))
-
 (defn connect [opts]
   (disconnect)
   (let [pipename (or (cfg [:pipename]) (a.get opts :port))]
@@ -143,8 +140,7 @@
            :pipename pipename
            :on-success
            (fn []
-             (display-repl-status)
-             (enter))
+             (display-repl-status))
            :on-error
            (fn [msg repl]
              (display-result msg)
@@ -153,11 +149,7 @@
            :on-close disconnect
            :on-stray-output display-result})))))
 
-(defn on-load []
-  (augroup
-    conjure-guile-socket-bufenter
-    (autocmd :BufEnter (.. :* buf-suffix) (viml->fn :enter)))
-  (connect))
+(defn on-load [])
 
 (defn on-exit []
   (disconnect))

--- a/fnl/conjure/client/guile/socket.fnl
+++ b/fnl/conjure/client/guile/socket.fnl
@@ -61,15 +61,10 @@
     (when (not (str.blank? clean))
       clean)))
 
-(defn- ctx-or-default [str]
-  (if str
-    str
-    "(guile-user)"))
-
 (defn eval-str [opts]
   (with-repl-or-warn
     (fn [repl]
-      (-?> (.. ",m " (ctx-or-default opts.context) "\n" opts.code)
+      (-?> (.. ",m " (or opts.context "(guile-user)") "\n" opts.code)
            (clean-input-code)
            (repl.send
              (fn [msgs]

--- a/lua/conjure/client/guile/socket.lua
+++ b/lua/conjure/client/guile/socket.lua
@@ -76,21 +76,13 @@ local function clean_input_code(code)
   end
 end
 _2amodule_locals_2a["clean-input-code"] = clean_input_code
-local function ctx_or_default(str0)
-  if str0 then
-    return str0
-  else
-    return "(guile-user)"
-  end
-end
-_2amodule_locals_2a["ctx-or-default"] = ctx_or_default
 local function eval_str(opts)
-  local function _7_(repl)
-    local _8_ = (",m " .. ctx_or_default(opts.context) .. "\n" .. opts.code)
-    if (nil ~= _8_) then
-      local _9_ = clean_input_code(_8_)
-      if (nil ~= _9_) then
-        local function _10_(msgs)
+  local function _6_(repl)
+    local _7_ = (",m " .. (opts.context or "(guile-user)") .. "\n" .. opts.code)
+    if (nil ~= _7_) then
+      local _8_ = clean_input_code(_7_)
+      if (nil ~= _8_) then
+        local function _9_(msgs)
           if ((1 == a.count(msgs)) and ("" == a["get-in"](msgs, {1, "out"}))) then
             a["assoc-in"](msgs, {1, "out"}, (comment_prefix .. "Empty result"))
           else
@@ -98,15 +90,15 @@ local function eval_str(opts)
           opts["on-result"](str.join("\n", format_message(a.last(msgs))))
           return a["run!"](display_result, msgs)
         end
-        return repl.send(_9_, _10_, {["batch?"] = true})
+        return repl.send(_8_, _9_, {["batch?"] = true})
       else
-        return _9_
+        return _8_
       end
     else
-      return _8_
+      return _7_
     end
   end
-  return with_repl_or_warn(_7_)
+  return with_repl_or_warn(_6_)
 end
 _2amodule_2a["eval-str"] = eval_str
 local function eval_file(opts)
@@ -114,16 +106,16 @@ local function eval_file(opts)
 end
 _2amodule_2a["eval-file"] = eval_file
 local function doc_str(opts)
-  local function _14_(_241)
+  local function _13_(_241)
     return ("(procedure-documentation " .. _241 .. ")")
   end
-  return eval_str(a.update(opts, "code", _14_))
+  return eval_str(a.update(opts, "code", _13_))
 end
 _2amodule_2a["doc-str"] = doc_str
 local function display_repl_status()
   local repl = state("repl")
   if repl then
-    local function _15_()
+    local function _14_()
       local pipename = a["get-in"](repl, {"opts", "pipename"})
       if pipename then
         return (pipename .. " ")
@@ -131,7 +123,7 @@ local function display_repl_status()
         return ""
       end
     end
-    local function _17_()
+    local function _16_()
       local err = a.get(repl, "err")
       if err then
         return (" " .. err)
@@ -139,7 +131,7 @@ local function display_repl_status()
         return ""
       end
     end
-    return log.append({(comment_prefix .. _15_() .. "(" .. repl.status .. _17_() .. ")")}, {["break?"] = true})
+    return log.append({(comment_prefix .. _14_() .. "(" .. repl.status .. _16_() .. ")")}, {["break?"] = true})
   else
     return nil
   end
@@ -176,16 +168,16 @@ local function connect(opts)
   if ("string" ~= type(pipename)) then
     return log.append({(comment_prefix .. "g:conjure#client#guile#socket#pipename is not specified"), (comment_prefix .. "Please set it to the name of your Guile REPL pipe or pass it to :ConjureConnect [pipename]")})
   else
-    local function _23_()
+    local function _22_()
       return display_repl_status()
     end
-    local function _24_(msg, repl)
+    local function _23_(msg, repl)
       display_result(msg)
-      local function _25_()
+      local function _24_()
       end
-      return repl.send(",q\n", _25_)
+      return repl.send(",q\n", _24_)
     end
-    return a.assoc(state(), "repl", socket.start({["parse-output"] = parse_guile_result, pipename = pipename, ["on-success"] = _23_, ["on-error"] = _24_, ["on-failure"] = disconnect, ["on-close"] = disconnect, ["on-stray-output"] = display_result}))
+    return a.assoc(state(), "repl", socket.start({["parse-output"] = parse_guile_result, pipename = pipename, ["on-success"] = _22_, ["on-error"] = _23_, ["on-failure"] = disconnect, ["on-close"] = disconnect, ["on-stray-output"] = display_result}))
   end
 end
 _2amodule_2a["connect"] = connect

--- a/lua/conjure/client/guile/socket.lua
+++ b/lua/conjure/client/guile/socket.lua
@@ -76,13 +76,21 @@ local function clean_input_code(code)
   end
 end
 _2amodule_locals_2a["clean-input-code"] = clean_input_code
+local function ctx_or_default(str0)
+  if str0 then
+    return str0
+  else
+    return "(guile-user)"
+  end
+end
+_2amodule_locals_2a["ctx-or-default"] = ctx_or_default
 local function eval_str(opts)
-  local function _6_(repl)
-    local _7_ = opts.code
-    if (nil ~= _7_) then
-      local _8_ = clean_input_code(_7_)
-      if (nil ~= _8_) then
-        local function _9_(msgs)
+  local function _7_(repl)
+    local _8_ = (",m " .. ctx_or_default(opts.context) .. "\n" .. opts.code)
+    if (nil ~= _8_) then
+      local _9_ = clean_input_code(_8_)
+      if (nil ~= _9_) then
+        local function _10_(msgs)
           if ((1 == a.count(msgs)) and ("" == a["get-in"](msgs, {1, "out"}))) then
             a["assoc-in"](msgs, {1, "out"}, (comment_prefix .. "Empty result"))
           else
@@ -90,15 +98,15 @@ local function eval_str(opts)
           opts["on-result"](str.join("\n", format_message(a.last(msgs))))
           return a["run!"](display_result, msgs)
         end
-        return repl.send(_8_, _9_, {["batch?"] = true})
+        return repl.send(_9_, _10_, {["batch?"] = true})
       else
-        return _8_
+        return _9_
       end
     else
-      return _7_
+      return _8_
     end
   end
-  return with_repl_or_warn(_6_)
+  return with_repl_or_warn(_7_)
 end
 _2amodule_2a["eval-str"] = eval_str
 local function eval_file(opts)
@@ -106,16 +114,16 @@ local function eval_file(opts)
 end
 _2amodule_2a["eval-file"] = eval_file
 local function doc_str(opts)
-  local function _13_(_241)
+  local function _14_(_241)
     return ("(procedure-documentation " .. _241 .. ")")
   end
-  return eval_str(a.update(opts, "code", _13_))
+  return eval_str(a.update(opts, "code", _14_))
 end
 _2amodule_2a["doc-str"] = doc_str
 local function display_repl_status()
   local repl = state("repl")
   if repl then
-    local function _14_()
+    local function _15_()
       local pipename = a["get-in"](repl, {"opts", "pipename"})
       if pipename then
         return (pipename .. " ")
@@ -123,7 +131,7 @@ local function display_repl_status()
         return ""
       end
     end
-    local function _16_()
+    local function _17_()
       local err = a.get(repl, "err")
       if err then
         return (" " .. err)
@@ -131,7 +139,7 @@ local function display_repl_status()
         return ""
       end
     end
-    return log.append({(comment_prefix .. _14_() .. "(" .. repl.status .. _16_() .. ")")}, {["break?"] = true})
+    return log.append({(comment_prefix .. _15_() .. "(" .. repl.status .. _17_() .. ")")}, {["break?"] = true})
   else
     return nil
   end
@@ -162,46 +170,26 @@ local function parse_guile_result(s)
   end
 end
 _2amodule_locals_2a["parse-guile-result"] = parse_guile_result
-local function enter()
-  local repl = state("repl")
-  local c = extract.context()
-  if (repl and ("connected" == repl.status)) then
-    local function _22_()
-    end
-    return repl.send((",m " .. (c or "(guile-user)") .. "\n"), _22_)
-  else
-    return nil
-  end
-end
-_2amodule_2a["enter"] = enter
 local function connect(opts)
   disconnect()
   local pipename = (cfg({"pipename"}) or a.get(opts, "port"))
   if ("string" ~= type(pipename)) then
     return log.append({(comment_prefix .. "g:conjure#client#guile#socket#pipename is not specified"), (comment_prefix .. "Please set it to the name of your Guile REPL pipe or pass it to :ConjureConnect [pipename]")})
   else
-    local function _24_()
-      display_repl_status()
-      return enter()
+    local function _23_()
+      return display_repl_status()
     end
-    local function _25_(msg, repl)
+    local function _24_(msg, repl)
       display_result(msg)
-      local function _26_()
+      local function _25_()
       end
-      return repl.send(",q\n", _26_)
+      return repl.send(",q\n", _25_)
     end
-    return a.assoc(state(), "repl", socket.start({["parse-output"] = parse_guile_result, pipename = pipename, ["on-success"] = _24_, ["on-error"] = _25_, ["on-failure"] = disconnect, ["on-close"] = disconnect, ["on-stray-output"] = display_result}))
+    return a.assoc(state(), "repl", socket.start({["parse-output"] = parse_guile_result, pipename = pipename, ["on-success"] = _23_, ["on-error"] = _24_, ["on-failure"] = disconnect, ["on-close"] = disconnect, ["on-stray-output"] = display_result}))
   end
 end
 _2amodule_2a["connect"] = connect
 local function on_load()
-  do
-    nvim.ex.augroup("conjure-guile-socket-bufenter")
-    nvim.ex.autocmd_()
-    nvim.ex.autocmd("BufEnter", ("*" .. buf_suffix), ("lua require('" .. _2amodule_name_2a .. "')['" .. "enter" .. "']()"))
-    nvim.ex.augroup("END")
-  end
-  return connect()
 end
 _2amodule_2a["on-load"] = on_load
 local function on_exit()


### PR DESCRIPTION
Using the Guile socket client, I noticed that my evaluations were not always getting evaluated in the correct context (module).  It was using the `BufEnter` autocmd, switching the module using the Guile REPL's `,m` command when the buffer changed.  It seems that this is not reliable, and sometimes it would fail to find the correct context and switch to the default module `(guile-user)` instead.  I think it might be somehow related to the presence of the log/HUD buffer, but I'm not sure at all.

This commit strips out all of the `BufEnter` stuff, and instead makes a separate `,m` command immediately before every evaluation.  The module name from `opts.context` in `eval-str`.

Whole file evaluations (`eval-file`) are run in the default module (`(guile-user)`), but if they begin with `(define-module ...)` then the end result is still correct: definitions within the file end up in the correct module.

The Racket client uses the same `BufEnter` system, and therefore almost certainly suffers from the same problem.

Extra discussion:
I tried to use the Guile REPL `,in` command (e.g. `,in (my module) (stuff to evaluate)`), but unfortunately this command requires the expression to be all on one line.  In the future, I'd like to have the Guile client inject a small "middleware" which can more elegantly handle evaluation of an expression within a specific module, and solve various other problems at the same time.  For example, the default REPL remembers all the evaluation results (so that they can be recalled with `$1`, `$2` etc), but this makes it possible to run out of memory fairly easily.  Definite link to #365 here.

