### PR TITLE
Strip shebang when auto require clojure

### DIFF
--- a/fnl/conjure/client/clojure/nrepl/init.fnl
+++ b/fnl/conjure/client/clojure/nrepl/init.fnl
@@ -105,6 +105,7 @@
 
 (defn context [header]
   (-?> header
+       (parse.strip-shebang)
        (parse.strip-meta)
        (parse.strip-comments)
        (string.match "%(%s*ns%s+([^)]*)")

--- a/fnl/conjure/client/clojure/nrepl/parse.fnl
+++ b/fnl/conjure/client/clojure/nrepl/parse.fnl
@@ -8,3 +8,7 @@
 (defn strip-comments [s]
   (-?> s
        (string.gsub ";.-[\n$]" "")))
+
+(defn strip-shebang [s]
+  (-?> s
+       (string.gsub "^#![^\n]*\n" "")))

--- a/lua/conjure/client/clojure/nrepl/init.lua
+++ b/lua/conjure/client/clojure/nrepl/init.lua
@@ -46,15 +46,20 @@ config.merge({client = {clojure = {nrepl = {connection = {default_host = "localh
 local function context(header)
   local _1_ = header
   if (nil ~= _1_) then
-    local _2_ = parse["strip-meta"](_1_)
+    local _2_ = parse["strip-shebang"](_1_)
     if (nil ~= _2_) then
-      local _3_ = parse["strip-comments"](_2_)
+      local _3_ = parse["strip-meta"](_2_)
       if (nil ~= _3_) then
-        local _4_ = string.match(_3_, "%(%s*ns%s+([^)]*)")
+        local _4_ = parse["strip-comments"](_3_)
         if (nil ~= _4_) then
-          local _5_ = str.split(_4_, "%s+")
+          local _5_ = string.match(_4_, "%(%s*ns%s+([^)]*)")
           if (nil ~= _5_) then
-            return a.first(_5_)
+            local _6_ = str.split(_5_, "%s+")
+            if (nil ~= _6_) then
+              return a.first(_6_)
+            else
+              return _6_
+            end
           else
             return _5_
           end

--- a/lua/conjure/client/clojure/nrepl/parse.lua
+++ b/lua/conjure/client/clojure/nrepl/parse.lua
@@ -33,4 +33,13 @@ local function strip_comments(s)
   end
 end
 _2amodule_2a["strip-comments"] = strip_comments
+local function strip_shebang(s)
+  local _7_ = s
+  if (nil ~= _7_) then
+    return string.gsub(_7_, "^#![^\n]*\n", "")
+  else
+    return _7_
+  end
+end
+_2amodule_2a["strip-shebang"] = strip_shebang
 return _2amodule_2a

--- a/test/fnl/conjure/client/clojure/nrepl/init-test.fnl
+++ b/test/fnl/conjure/client/clojure/nrepl/init-test.fnl
@@ -9,6 +9,7 @@
   (t.= "foo" (clj.context "(ns ^:bar foo baz") "short meta missing closing paren")
   (t.= "foo" (clj.context "(ns ^{:bar true} foo baz)") "long meta")
   (t.= "foo" (clj.context "(ns \n^{:bar true} foo\n \"some docs\"\n baz") "newlines and docs")
+  (t.= "foo" (clj.context "#!/usr/bin/env bb\n(ns ^:bar foo)\n(def foo1 1)" "strip shebang"))
 
   ;; https://github.com/Olical/conjure/issues/204
   (t.= "foo" (clj.context "(ns ^{:clj-kondo/config {:lint-as '{my-awesome/defn-like-macro clojure.core/defn}}} foo)"))


### PR DESCRIPTION
Hi! This little commit makes auto require work for babashka files that start with a shebang