### PR TITLE
allow custom user environment variables

### DIFF
--- a/fnl/conjure/remote/stdio.fnl
+++ b/fnl/conjure/remote/stdio.fnl
@@ -117,11 +117,13 @@
           (uv.spawn cmd {:stdio [stdin stdout stderr]
                          :args args
                          :env (extend-env
-                                ;; Trying to disable custom readline config.
-                                ;; Doesn't work in practice but is probably close?
-                                ;; If you know how, please open a PR!
-                                {:INPUTRC "/dev/null"
-                                 :TERM "dumb"})}
+                                (a.merge!
+                                  opts.env
+                                  ;; Trying to disable custom readline config.
+                                  ;; Doesn't work in practice but is probably close?
+                                  ;; If you know how, please open a PR!
+                                  {:INPUTRC "/dev/null"
+                                   :TERM "dumb"}))}
                     (client.schedule-wrap on-exit))]
       (if handle
         (do

--- a/lua/conjure/remote/stdio.lua
+++ b/lua/conjure/remote/stdio.lua
@@ -161,7 +161,7 @@ local function start(opts)
   local _let_25_ = parse_cmd(opts.cmd)
   local cmd = _let_25_["cmd"]
   local args = _let_25_["args"]
-  local handle, pid_or_err = uv.spawn(cmd, {stdio = {stdin, stdout, stderr}, args = args, env = extend_env({INPUTRC = "/dev/null", TERM = "dumb"})}, client["schedule-wrap"](on_exit))
+  local handle, pid_or_err = uv.spawn(cmd, {stdio = {stdin, stdout, stderr}, args = args, env = extend_env(a["merge!"](opts.env, {INPUTRC = "/dev/null", TERM = "dumb"}))}, client["schedule-wrap"](on_exit))
   if handle then
     stdout:read_start(client["schedule-wrap"](on_stdout))
     stderr:read_start(client["schedule-wrap"](on_stderr))


### PR DESCRIPTION
This allows passing custom env in the config via `:env` this is useful for some repls like deno which needs `NO_COLOR=1`