### PR TITLE
Add descriptiors for other mappings

### DIFF
--- a/fnl/conjure/mapping.fnl
+++ b/fnl/conjure/mapping.fnl
@@ -26,23 +26,23 @@
    :log_reset_hard "Hard reset log"
    :log_jump_to_latest "Jump to latest part of log"
 
-   ;; :eval_current_form "ee"
-   ;; :eval_comment_current_form "ece"
-   ;;
-   ;; :eval_root_form "er"
-   ;; :eval_comment_root_form "ecr"
-   ;;
-   ;; :eval_word "ew"
-   ;; :eval_comment_word "ecw"
-   ;;
-   ;; :eval_replace_form "e!"
-   ;; :eval_marked_form "em"
-   ;; :eval_file "ef"
-   ;; :eval_buf "eb"
-   ;; :eval_visual "E"
-   ;; :eval_motion "E"
-   ;; :def_word "gd"
-   ;; :doc_word ["K"]
+   :eval_current_form "Evaluate current form"
+   :eval_comment_current_form "Evaluate current form and comment result"
+
+   :eval_root_form "Evaluate root form"
+   :eval_comment_root_form "Evaluate root form and comment result"
+
+   :eval_word "Evaluate word"
+   :eval_comment_word "Evaluate word and comment result"
+
+   :eval_replace_form "Evaluate form and replace with result"
+   :eval_marked_form "Evaluate marked form"
+   :eval_file "Evaluate file"
+   :eval_buf "Evaluate buffer"
+   :eval_visual "Evaluate visual select"
+   :eval_motion "Evaluate motion"
+   :def_word "Get definition under cursor"
+   :doc_word "Get documentation under cursor"
    })
 
 (defn- desc [k]

--- a/lua/conjure/mapping.lua
+++ b/lua/conjure/mapping.lua
@@ -28,7 +28,7 @@ local function cfg(k)
   return config["get-in"]({"mapping", k})
 end
 _2amodule_locals_2a["cfg"] = cfg
-local mapping_descriptions = {log_split = "Open log in new horizontal split window", log_vsplit = "Open log in new vertical split window", log_tab = "Open log in new tab", log_buf = "Open log in new buffer", log_toggle = "Toggle log buffer", log_close_visible = "Close all visible log windows", log_reset_soft = "Soft reset log", log_reset_hard = "Hard reset log", log_jump_to_latest = "Jump to latest part of log"}
+local mapping_descriptions = {log_split = "Open log in new horizontal split window", log_vsplit = "Open log in new vertical split window", log_tab = "Open log in new tab", log_buf = "Open log in new buffer", log_toggle = "Toggle log buffer", log_close_visible = "Close all visible log windows", log_reset_soft = "Soft reset log", log_reset_hard = "Hard reset log", log_jump_to_latest = "Jump to latest part of log", eval_current_form = "Evaluate current form", eval_comment_current_form = "Evaluate current form and comment result", eval_root_form = "Evaluate root form", eval_comment_root_form = "Evaluate root form and comment result", eval_word = "Evaluate word", eval_comment_word = "Evaluate word and comment result", eval_replace_form = "Evaluate form and replace with result", eval_marked_form = "Evaluate marked form", eval_file = "Evaluate file", eval_buf = "Evaluate buffer", eval_visual = "Evaluate visual select", eval_motion = "Evaluate motion", def_word = "Get definition under cursor", doc_word = "Get documentation under cursor"}
 _2amodule_locals_2a["mapping-descriptions"] = mapping_descriptions
 local function desc(k)
   return a.get(mapping_descriptions, k)


### PR DESCRIPTION
I noticed that with `buf2` on develop that missing descriptions show nothing
![SCR-20220911-lrw](https://user-images.githubusercontent.com/497310/189549999-2f90894b-e56a-43c6-9de9-f8838f86412a.png)

That's because you're using `:callback`. With 'legacy' `buf` you see the mapping, which is a bit friendlier:
![SCR-20220911-lsk](https://user-images.githubusercontent.com/497310/189550031-11a81871-0c6b-4a4f-bdc0-458712217e5b.png)

So I figured I'd push some descriptions for the ones I didn't do before.
