### PR TITLE
Explicitly load newly created log buffer

### DIFF
--- a/fnl/conjure/buffer.fnl
+++ b/fnl/conjure/buffer.fnl
@@ -19,7 +19,9 @@
     (if (or (= -1 buf) (not loaded?))
       (let [buf (if loaded?
                   buf
-                  (nvim.fn.bufadd buf-name))]
+                  (let [buf (nvim.fn.bufadd buf-name)]
+                    (nvim.fn.bufload buf)
+                    buf))]
         (nvim.buf_set_option buf :buftype :nofile)
         (nvim.buf_set_option buf :bufhidden :hide)
         (nvim.buf_set_option buf :swapfile false)

--- a/lua/conjure/buffer.lua
+++ b/lua/conjure/buffer.lua
@@ -32,7 +32,9 @@ local function upsert_hidden(buf_name, new_buf_fn)
     if loaded_3f then
       buf0 = buf
     else
-      buf0 = nvim.fn.bufadd(buf_name)
+      local buf1 = nvim.fn.bufadd(buf_name)
+      nvim.fn.bufload(buf1)
+      buf0 = buf1
     end
     nvim.buf_set_option(buf0, "buftype", "nofile")
     nvim.buf_set_option(buf0, "bufhidden", "hide")


### PR DESCRIPTION
Possible fix for #419 