### PR TITLE
fix for issue #437

### DIFF
--- a/fnl/conjure/client/python/stdio.fnl
+++ b/fnl/conjure/client/python/stdio.fnl
@@ -93,11 +93,17 @@
 
 (defn- escape-strs
   [s]
-  (string.gsub s "\"" "\\\""))
+  ;; Split s into multiple lines based on newlines.
+  ;; Escape internal escaped newlines in each line if any.
+  ;; Return lines joined backed together with newlines as a single string.
+  (let [s2 (str.split s "\n")
+        lns (icollect [i val (ipairs s2)]
+              (string.gsub val "\\n" "\\\\n"))]
+    (.. (a.first lns) "\n" (str.join "\n" (a.rest lns)))))
 
 (defn- get-exec-str
   [s]
-  (.. "exec(\"\"\"\n" (escape-strs s) "\n\"\"\")\n"))
+  (.. "exec('''\n" (escape-strs s) "\n''')\n"))
 
 (defn- prep-code [s]
   (let [python-expr (str-is-python-expr? s)]


### PR DESCRIPTION
I think I've solved the problem with embedded newline characters in Python source code. All of the examples in `dev/python/sandbox.py` evaluate correctly. I haven't tried it with other Python files yet. Just wanted to get something working for others to try on their code.