### PR TITLE
fix(swank): improve doc-str to work with any objects, not only functions

### DIFF
--- a/fnl/conjure/client/common-lisp/swank.fnl
+++ b/fnl/conjure/client/common-lisp/swank.fnl
@@ -253,7 +253,7 @@
 
 (defn doc-str [opts]
   (try-ensure-conn)
-  (eval-str (a.update opts :code #(.. "(describe #'" $1 ")"))))
+  (eval-str (a.update opts :code #(.. "(describe '" $1 ")"))))
 
 (defn eval-file [opts]
   (try-ensure-conn)

--- a/lua/conjure/client/common-lisp/swank.lua
+++ b/lua/conjure/client/common-lisp/swank.lua
@@ -268,7 +268,7 @@ _2amodule_2a["eval-str"] = eval_str
 local function doc_str(opts)
   try_ensure_conn()
   local function _34_(_241)
-    return ("(describe #'" .. _241 .. ")")
+    return ("(describe '" .. _241 .. ")")
   end
   return eval_str(a.update(opts, "code", _34_))
 end


### PR DESCRIPTION
Honestly, I'm not familiar with common lisp (only touching it lesser than a week), so will be good if someone with good common lisp knowledge approve it.

---

Original doc-str was constructing things like: `(describe #'list)`

<details> 
  <summary>Eval result</summary>

```lisp
(describe #'list)
; #<FUNCTION LIST>
;   [compiled function]
; 
; 
; Lambda-list: (&REST ARGS)
; Declared type: (FUNCTION * (VALUES LIST &OPTIONAL))
; Derived type: (FUNCTION (&REST T) (VALUES LIST &OPTIONAL))
; Documentation:
;   Construct and return a list containing the objects ARGS.
; Known attributes: flushable, unsafely-flushable, movable
; Source file: SYS:SRC;CODE;LIST.LISP
```
</details>

and: `(describe #'defun)`

<details> 
  <summary>Eval result</summary>

```lisp
(describe #'defun)
; COMMON-LISP:DEFUN is a macro, not a function.
```
</details>

---

When with this fix it does: `(describe 'list)`

<details> 
  <summary>Eval result</summary>

```lisp
(describe 'list)
; COMMON-LISP:LIST
;   [symbol]
; 
; LIST names a compiled function:
;   Lambda-list: (&REST ARGS)
;   Declared type: (FUNCTION * (VALUES LIST &OPTIONAL))
;   Derived type: (FUNCTION (&REST T) (VALUES LIST &OPTIONAL))
;   Documentation:
;     Construct and return a list containing the objects ARGS.
;   Known attributes: flushable, unsafely-flushable, movable
;   Source file: SYS:SRC;CODE;LIST.LISP
; 
; LIST names the built-in-class #<BUILT-IN-CLASS COMMON-LISP:LIST>:
;   Class precedence-list: LIST, SEQUENCE, T
;   Direct superclasses: SEQUENCE
;   Direct subclasses: CONS, NULL
;   Sealed.
;   No direct slots.
```
</details>

and: `(describe 'defun)`

<details> 
  <summary>Eval result</summary>

```lisp
(describe 'defun)
; COMMON-LISP:DEFUN
;   [symbol]
; 
; DEFUN names a macro:
;   Lambda-list: (NAME LAMBDA-LIST &BODY BODY)
;   Documentation:
;     Define a function at top level.
;   Source file: SYS:SRC;CODE;MACROS.LISP
```
</details>

So it works both for functions and macros (and whatever other?)
