### PR TITLE
fix(deprecation): update treesitter function

### DIFF
--- a/fnl/conjure/client/python/stdio.fnl
+++ b/fnl/conjure/client/python/stdio.fnl
@@ -213,7 +213,9 @@
                      (config.get-in [:mapping :prefix])
                      (cfg [:mapping :stop]))]
                 {:break? true})
-    (if (not (pcall #(vim.treesitter.require_language "python")))
+    (if (not (pcall #(if vim.treesitter.language.require_language
+                       (vim.treesitter.language.require_language "python")
+                       (vim.treesitter.require_language "python"))))
       (log.append [(.. comment-prefix "(error) The python client requires a python treesitter parser in order to function.")
                    (.. comment-prefix "(error) See https://github.com/nvim-treesitter/nvim-treesitter")
                    (.. comment-prefix "(error) for installation instructions.")])

--- a/fnl/conjure/tree-sitter.fnl
+++ b/fnl/conjure/tree-sitter.fnl
@@ -37,7 +37,9 @@
   "Turn the node into a string, nils flow through. Separate forms are joined by
   new lines."
   (when node
-    (vim.treesitter.query.get_node_text node (nvim.get_current_buf))))
+    (if vim.treesitter.get_node_text
+      (vim.treesitter.get_node_text node (nvim.get_current_buf))
+      (vim.treesitter.query.get_node_text node (nvim.get_current_buf)))))
 
 (defn lisp-comment-node? [node]
   "Node is a (comment ...) form"

--- a/lua/conjure/client/python/stdio.lua
+++ b/lua/conjure/client/python/stdio.lua
@@ -196,7 +196,11 @@ local function start()
     return log.append({(comment_prefix .. "Can't start, REPL is already running."), (comment_prefix .. "Stop the REPL with " .. config["get-in"]({"mapping", "prefix"}) .. cfg({"mapping", "stop"}))}, {["break?"] = true})
   else
     local function _18_()
-      return vim.treesitter.require_language("python")
+      if vim.treesitter.language.require_language then
+        return vim.treesitter.language.require_language("python")
+      else
+        return vim.treesitter.require_language("python")
+      end
     end
     if not pcall(_18_) then
       return log.append({(comment_prefix .. "(error) The python client requires a python treesitter parser in order to function."), (comment_prefix .. "(error) See https://github.com/nvim-treesitter/nvim-treesitter"), (comment_prefix .. "(error) for installation instructions.")})

--- a/lua/conjure/tree-sitter.lua
+++ b/lua/conjure/tree-sitter.lua
@@ -55,7 +55,11 @@ end
 _2amodule_2a["parse!"] = parse_21
 local function node__3estr(node)
   if node then
-    return vim.treesitter.query.get_node_text(node, nvim.get_current_buf())
+    if vim.treesitter.get_node_text then
+      return vim.treesitter.get_node_text(node, nvim.get_current_buf())
+    else
+      return vim.treesitter.query.get_node_text(node, nvim.get_current_buf())
+    end
   else
     return nil
   end


### PR DESCRIPTION
see https://github.com/neovim/neovim/pull/22761
vim.treesitter.query.get_node_text is deprecated, use new api instead

also resolve https://github.com/Olical/conjure/issues/477