### PR TITLE
Fix for issue #497 Scheme client

### DIFF
--- a/doc/conjure-client-scheme-stdio.txt
+++ b/doc/conjure-client-scheme-stdio.txt
@@ -37,6 +37,9 @@ options relevant to these mappings.
 
 <localleader>cS          Stop any existing Scheme REPL.
 
+<localleader>ei          Interrupt running command. Same as pressing Ctrl-C
+                         in a cmdline REPL.
+
 ==============================================================================
 CONFIGURATION                      *conjure-client-scheme-stdio-configuration*
 

--- a/fnl/conjure/client/scheme/stdio.fnl
+++ b/fnl/conjure/client/scheme/stdio.fnl
@@ -15,7 +15,8 @@
    {:scheme
     {:stdio
      {:mapping {:start "cs"
-                :stop "cS"}
+                :stop "cS"
+                :interrupt "ei"}
       :command "mit-scheme"
       ;; Match "]=> " or "error> "
       :prompt_pattern "[%]e][=r]r?o?r?> "
@@ -119,6 +120,12 @@
          (fn [msg]
            (log.append (format-msg msg)))}))))
 
+(defn interrupt []
+  (with-repl-or-warn
+    (fn [repl]
+      (log.append ["; Sending interrupt signal."] {:break? true})
+      (repl.send-signal 2))))
+
 (defn on-load []
   (start))
 
@@ -131,7 +138,13 @@
   (mapping.buf
     :SchemeStop (cfg [:mapping :stop])
     stop
-    {:desc "Stop the REPL"}))
+    {:desc "Stop the REPL"})
+
+  (mapping.buf
+    :SchemeInterrupt (cfg [:mapping :interrupt])
+    interrupt
+    {:desc "Interrupt the REPL"}))
 
 (defn on-exit []
   (stop))
+

--- a/fnl/conjure/client/scheme/stdio.fnl
+++ b/fnl/conjure/client/scheme/stdio.fnl
@@ -123,8 +123,8 @@
 (defn interrupt []
   (with-repl-or-warn
     (fn [repl]
-      (log.append ["; Sending interrupt signal."] {:break? true})
-      (repl.send-signal 2))))
+      (log.append [(.. comment-prefix " Sending interrupt signal.")] {:break? true})
+      (repl.send-signal vim.loop.constants.SIGINT))))
 
 (defn on-load []
   (start))

--- a/lua/conjure/client/guile/socket.lua
+++ b/lua/conjure/client/guile/socket.lua
@@ -157,7 +157,7 @@ local function parse_guile_result(s)
     if s:find("scheme@%([%w%-%s]+%) %[%d+%]>") then
       return {["done?"] = true, ["error?"] = true, result = nil}
     else
-      return {result = s, ["error?"] = false, ["done?"] = false}
+      return {result = s, ["done?"] = false, ["error?"] = false}
     end
   end
 end

--- a/lua/conjure/client/guile/socket.lua
+++ b/lua/conjure/client/guile/socket.lua
@@ -157,7 +157,7 @@ local function parse_guile_result(s)
     if s:find("scheme@%([%w%-%s]+%) %[%d+%]>") then
       return {["done?"] = true, ["error?"] = true, result = nil}
     else
-      return {result = s, ["done?"] = false, ["error?"] = false}
+      return {result = s, ["error?"] = false, ["done?"] = false}
     end
   end
 end

--- a/lua/conjure/client/scheme/stdio.lua
+++ b/lua/conjure/client/scheme/stdio.lua
@@ -22,7 +22,7 @@ _2amodule_locals_2a["stdio"] = stdio
 _2amodule_locals_2a["str"] = str
 _2amodule_locals_2a["ts"] = ts
 _2amodule_locals_2a["_"] = _
-config.merge({client = {scheme = {stdio = {mapping = {start = "cs", stop = "cS"}, command = "mit-scheme", prompt_pattern = "[%]e][=r]r?o?r?> ", value_prefix_pattern = "^;Value: "}}}})
+config.merge({client = {scheme = {stdio = {mapping = {start = "cs", stop = "cS", interrupt = "ei"}, command = "mit-scheme", prompt_pattern = "[%]e][=r]r?o?r?> ", value_prefix_pattern = "^;Value: "}}}})
 local cfg = config["get-in-fn"]({"client", "scheme", "stdio"})
 do end (_2amodule_locals_2a)["cfg"] = cfg
 local state
@@ -128,13 +128,22 @@ local function start()
   end
 end
 _2amodule_2a["start"] = start
+local function interrupt()
+  local function _17_(repl)
+    log.append({"; Sending interrupt signal."}, {["break?"] = true})
+    return repl["send-signal"](2)
+  end
+  return with_repl_or_warn(_17_)
+end
+_2amodule_2a["interrupt"] = interrupt
 local function on_load()
   return start()
 end
 _2amodule_2a["on-load"] = on_load
 local function on_filetype()
   mapping.buf("SchemeStart", cfg({"mapping", "start"}), start, {desc = "Start the REPL"})
-  return mapping.buf("SchemeStop", cfg({"mapping", "stop"}), stop, {desc = "Stop the REPL"})
+  mapping.buf("SchemeStop", cfg({"mapping", "stop"}), stop, {desc = "Stop the REPL"})
+  return mapping.buf("SchemeInterrupt", cfg({"mapping", "interrupt"}), interrupt, {desc = "Interrupt the REPL"})
 end
 _2amodule_2a["on-filetype"] = on_filetype
 local function on_exit()

--- a/lua/conjure/client/scheme/stdio.lua
+++ b/lua/conjure/client/scheme/stdio.lua
@@ -130,8 +130,8 @@ end
 _2amodule_2a["start"] = start
 local function interrupt()
   local function _17_(repl)
-    log.append({"; Sending interrupt signal."}, {["break?"] = true})
-    return repl["send-signal"](2)
+    log.append({(comment_prefix .. " Sending interrupt signal.")}, {["break?"] = true})
+    return repl["send-signal"](vim.loop.constants.SIGINT)
   end
   return with_repl_or_warn(_17_)
 end


### PR DESCRIPTION
Sorry, had to create another branch in my fork to isolate my other PR from this one.

I copied the interrupt function from the Racket client instead of the Python client because the Racket one uses the `send-signal` function from the base functionality in`remote/stdio.fnl`.