### PR TITLE
Use repl.send-signal to interrupt stdio REPLs

### DIFF
--- a/fnl/conjure/client/hy/stdio.fnl
+++ b/fnl/conjure/client/hy/stdio.fnl
@@ -155,8 +155,9 @@
   (log.dbg "sending interrupt message" "")
   (with-repl-or-warn
     (fn [repl]
-      (let [uv vim.loop]
-        (uv.kill repl.pid uv.constants.SIGINT)))))
+      (log.append [(.. comment-prefix " Sending interrupt signal.")] {:break? true})
+      (log.append ["; Sending interrupt signal."] {:break? true})
+      (repl.send-signal vim.loop.constants.SIGINT))))
 
 (defn on-filetype []
   (mapping.buf

--- a/fnl/conjure/client/julia/stdio.fnl
+++ b/fnl/conjure/client/julia/stdio.fnl
@@ -152,8 +152,8 @@
 (defn interrupt []
   (with-repl-or-warn
     (fn [repl]
-      (let [uv vim.loop]
-        (uv.kill repl.pid uv.constants.SIGINT)))))
+      (log.append [(.. comment-prefix " Sending interrupt signal.")] {:break? true})
+      (repl.send-signal vim.loop.constants.SIGINT))))
 
 (defn on-filetype []
   (mapping.buf

--- a/fnl/conjure/client/python/stdio.fnl
+++ b/fnl/conjure/client/python/stdio.fnl
@@ -264,8 +264,8 @@
 (defn interrupt []
   (with-repl-or-warn
     (fn [repl]
-      (let [uv vim.loop]
-        (uv.kill repl.pid uv.constants.SIGINT)))))
+      (log.append [(.. comment-prefix " Sending interrupt signal.")] {:break? true})
+      (repl.send-signal vim.loop.constants.SIGINT))))
 
 (defn on-filetype []
   (mapping.buf

--- a/fnl/conjure/client/racket/stdio.fnl
+++ b/fnl/conjure/client/racket/stdio.fnl
@@ -71,11 +71,8 @@
 (defn interrupt []
   (with-repl-or-warn
     (fn [repl]
-      (log.append ["; Sending interrupt signal."] {:break? true})
-
-      ;; SIGINT C-c
-      ;; https://github.com/Olical/conjure/issues/213
-      (repl.send-signal 2))))
+      (log.append [(.. comment-prefix " Sending interrupt signal.")] {:break? true})
+      (repl.send-signal vim.loop.constants.SIGINT))))
 
 (defn eval-file [opts]
   (eval-str (a.assoc opts :code (.. ",require-reloadable " opts.file-path))))

--- a/lua/conjure/client/hy/stdio.lua
+++ b/lua/conjure/client/hy/stdio.lua
@@ -195,8 +195,9 @@ _2amodule_2a["on-exit"] = on_exit
 local function interrupt()
   log.dbg("sending interrupt message", "")
   local function _26_(repl)
-    local uv = vim.loop
-    return uv.kill(repl.pid, uv.constants.SIGINT)
+    log.append({(comment_prefix .. " Sending interrupt signal.")}, {["break?"] = true})
+    log.append({"; Sending interrupt signal."}, {["break?"] = true})
+    return repl["send-signal"](vim.loop.constants.SIGINT)
   end
   return with_repl_or_warn(_26_)
 end

--- a/lua/conjure/client/julia/stdio.lua
+++ b/lua/conjure/client/julia/stdio.lua
@@ -164,8 +164,8 @@ end
 _2amodule_2a["on-exit"] = on_exit
 local function interrupt()
   local function _21_(repl)
-    local uv = vim.loop
-    return uv.kill(repl.pid, uv.constants.SIGINT)
+    log.append({(comment_prefix .. " Sending interrupt signal.")}, {["break?"] = true})
+    return repl["send-signal"](vim.loop.constants.SIGINT)
   end
   return with_repl_or_warn(_21_)
 end

--- a/lua/conjure/client/python/stdio.lua
+++ b/lua/conjure/client/python/stdio.lua
@@ -250,8 +250,8 @@ end
 _2amodule_2a["on-exit"] = on_exit
 local function interrupt()
   local function _31_(repl)
-    local uv = vim.loop
-    return uv.kill(repl.pid, uv.constants.SIGINT)
+    log.append({(comment_prefix .. " Sending interrupt signal.")}, {["break?"] = true})
+    return repl["send-signal"](vim.loop.constants.SIGINT)
   end
   return with_repl_or_warn(_31_)
 end

--- a/lua/conjure/client/racket/stdio.lua
+++ b/lua/conjure/client/racket/stdio.lua
@@ -89,8 +89,8 @@ end
 _2amodule_2a["eval-str"] = eval_str
 local function interrupt()
   local function _8_(repl)
-    log.append({"; Sending interrupt signal."}, {["break?"] = true})
-    return repl["send-signal"](2)
+    log.append({(comment_prefix .. " Sending interrupt signal.")}, {["break?"] = true})
+    return repl["send-signal"](vim.loop.constants.SIGINT)
   end
   return with_repl_or_warn(_8_)
 end


### PR DESCRIPTION
This is a minor nit but I noticed that the stdio-based clients use two equivalent implementations of the `interrupt` function. This PR makes the implementation the same for these clients:
- Hy
- Julia
- Python
- Racket

by using the:
- `send-signal` function defined in `remote/stdio.fnl`
- `vim.loop.constants.SIGINT` constant instead of the number 2
- `comment-prefix` of the client's language

Hopefully, this provides consistency and emphasizes the use of the base client functionality of `remote/stdio.fnl`.

I didn't include the Scheme client because there is https://github.com/Olical/conjure/pull/498 which adds the ability to interrupt the REPL.