### PR TITLE
docs: remove g:conjure#mapping#eval_comment_form (unused)

### DIFF
--- a/doc/conjure.txt
+++ b/doc/conjure.txt
@@ -486,12 +486,6 @@ configuring these values from Lua it's just `true` and `false`.
             Evaluates the form at the marks location.
             Default: `"em"`
 
-                                         *g:conjure#mapping#eval_comment_form*
-`g:conjure#mapping#eval_comment_form`
-            Evaluates the form under the cursor and displays the result as a
-            comment at the end of the current line or below the current line.
-            Default: `"ec"`
-
                                                  *g:conjure#mapping#eval_file*
 `g:conjure#mapping#eval_file`
             Evaluates the file from disk.


### PR DESCRIPTION
Hi,

I noticed that the mapping `g:conjure#mapping#eval_comment_form`, which defaults to `ec`, doesn't really exist. I've checked the source code and it seems that it's not used anywhere, so I think we can safely remove it from the doc to avoid any confusion.

Thank you for creating and maintaining this amazing project!