### PR TITLE
Common-Lisp: Use interactive-eval-region

### DIFF
--- a/fnl/conjure/client/common-lisp/swank.fnl
+++ b/fnl/conjure/client/common-lisp/swank.fnl
@@ -87,7 +87,7 @@
         (remote.send
           conn
           (str.join
-            ["(:emacs-rex (swank:eval-and-grab-output \""
+            ["(:emacs-rex (swank:interactive-eval-region \""
              (escape-string msg)
              "\") \"" (or context ":common-lisp-user") "\" t " eval-id ")"])
           cb)))))

--- a/lua/conjure/client/common-lisp/swank.lua
+++ b/lua/conjure/client/common-lisp/swank.lua
@@ -87,7 +87,7 @@ local function send(msg, context, cb)
   log.dbg(("swank.send called with msg: " .. a["pr-str"](msg) .. ", context: " .. a["pr-str"](context)))
   local function _7_(conn)
     local eval_id = a.get(a.update(state(), "eval-id", a.inc), "eval-id")
-    return remote.send(conn, str.join({"(:emacs-rex (swank:eval-and-grab-output \"", escape_string(msg), "\") \"", (context or ":common-lisp-user"), "\" t ", eval_id, ")"}), cb)
+    return remote.send(conn, str.join({"(:emacs-rex (swank:interactive-eval-region \"", escape_string(msg), "\") \"", (context or ":common-lisp-user"), "\" t ", eval_id, ")"}), cb)
   end
   return with_conn_or_warn(_7_)
 end


### PR DESCRIPTION
**Disclaimer:** I have absolutely no idea what I'm doing. I captured some logs from emacs' SLY with wireshark and noticed that SLY uses `interactive-eval-region` for its buffer evaluation while we're using `eval-and-grab-output`. I have no idea why, but it seems to fix the ConjureEvalBuf only loading the first expression seen in #555. 

The swank source is totally opaque to me, but someone else may find it useful: https://github.com/slime/slime/blob/master/swank.lisp.

Prefer interactive-eval-region over eval-and-grab-output, as the latter requires list output parsing.