### PR TITLE
Debugger: Show value of :debug-value if present

### DIFF
--- a/fnl/conjure/client/clojure/nrepl/debugger.fnl
+++ b/fnl/conjure/client/clojure/nrepl/debugger.fnl
@@ -65,6 +65,9 @@
         {})
       {}))
 
+  (when (not (a.nil? msg.debug-value))
+    (log.append [(a.str "; Evaluation result => " msg.debug-value)] {}))
+
   (if (a.empty? msg.prompt)
     (log.append
       ["; Respond with :ConjureCljDebugInput [input]"

--- a/lua/conjure/client/clojure/nrepl/debugger.lua
+++ b/lua/conjure/client/clojure/nrepl/debugger.lua
@@ -79,6 +79,10 @@ local function handle_input_request(msg)
     log.append(text["prefixed-lines"](render_inspect(elisp.read(msg.inspect)), "; ", {}), {})
   else
   end
+  if not a["nil?"](msg["debug-value"]) then
+    log.append({a.str("; Evaluation result => ", msg["debug-value"])}, {})
+  else
+  end
   if a["empty?"](msg.prompt) then
     return log.append({"; Respond with :ConjureCljDebugInput [input]", ("; Inputs: " .. str.join(", ", valid_inputs()))}, {})
   else
@@ -87,10 +91,10 @@ local function handle_input_request(msg)
 end
 _2amodule_2a["handle-input-request"] = handle_input_request
 local function debug_input(opts)
-  local function _10_(_241)
+  local function _11_(_241)
     return (opts.args == _241)
   end
-  if a.some(_10_, valid_inputs()) then
+  if a.some(_11_, valid_inputs()) then
     return send({input = (":" .. opts.args)})
   else
     return log.append({("; Valid inputs: " .. str.join(", ", valid_inputs()))})


### PR DESCRIPTION
When using the debugger, results from `:ConjureCljDebugInput eval` were not being displayed in the log buffer. It looks like these results are returned in the `:debug-value` field, so Conjure just needs to check if that field is available and print it if so.

For comparison, [here](https://github.com/clojure-emacs/cider-nrepl/blob/3824d72f9ba1a14f9ce9910500db0885f6b39c23/src/cider/nrepl/middleware/debug.clj#L390) is where the result is read in `cider-nrepl`, confirming that this is indeed the right field.