### PR TITLE
Refactor fs.fnl to use nvim 0.8 builtins

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -65,7 +65,7 @@ This will temporarily download the plugin, launch Neovim with `:ConjureSchool` r
 
 == Installation
 
-Requires Neovim 0.7 or newer.
+Requires Neovim 0.8 or newer.
 
 Alternatively you can use https://github.com/Olical/magic-kit[Magic Kit], an opinionated starter kit that includes all sorts of essential tools.
 

--- a/fnl/conjure/fs.fnl
+++ b/fnl/conjure/fs.fnl
@@ -1,39 +1,37 @@
 (local {: autoload} (require :nfnl.module))
-(local nvim (autoload :conjure.aniseed.nvim))
 (local a (autoload :conjure.aniseed.core))
-(local text (autoload :conjure.text))
 (local str (autoload :conjure.aniseed.string))
-(local afs (autoload :conjure.aniseed.fs))
 (local config (autoload :conjure.config))
 
+(local path-sep (if (= jit.os :Windows) "\\" "/"))
+
 (fn env [k]
-  (let [v (nvim.fn.getenv k)]
+  (let [v (vim.fn.getenv k)]
     (when (and (a.string? v) (not (a.empty? v)))
       v)))
 
 (fn config-dir []
   "Return $XDG_CONFIG_HOME/conjure.
   Defaulting the config directory to $HOME/.config."
-  (.. (or (env "XDG_CONFIG_HOME")
-          (.. (env "HOME") afs.path-sep ".config"))
-      afs.path-sep "conjure"))
+  (vim.fs.normalize (if (env "XDG_CONFIG_HOME")
+                        "$XDG_CONFIG_HOME/conjure" 
+                        "~/.config/conjure")))
 
 (fn absolute-path [path]
-  (vim.fn.fnamemodify path ":p"))
+  (vim.fs.normalize (vim.fn.fnamemodify path ":p")))
 
 (fn findfile [name path]
   "Wrapper around Neovim's findfile() that returns nil
   instead of an empty string."
-  (let [res (nvim.fn.findfile name path)]
+  (let [res (vim.fn.findfile name path)]
     (when (not (a.empty? res))
       (absolute-path res))))
 
 (fn split-path [path]
-  (->> (str.split path afs.path-sep)
-       (a.filter #(not (a.empty? $)))))
+  (vim.split path path-sep {:trimempty true}))
 
 (fn join-path [parts]
-  (str.join afs.path-sep (a.concat parts)))
+  (str.join path-sep (a.concat parts)))
 
 (fn parent-dir [path]
   (let [res (-> path
@@ -42,7 +40,7 @@
                 (join-path))]
     (if (= "" res)
       nil
-      (.. afs.path-sep res))))
+      (.. path-sep res))))
 
 (fn upwards-file-search [file-names from-dir]
   "Given a list of relative filenames and an absolute path to a directory,
@@ -68,12 +66,12 @@
   first file name in the first directory, everything will short circuit and
   return that full path."
   (or
-    (upwards-file-search names (nvim.fn.expand "%:p:h"))
-    (upwards-file-search names (nvim.fn.getcwd))
+    (upwards-file-search names (vim.fn.expand "%:p:h"))
+    (upwards-file-search names (vim.fn.getcwd))
     (upwards-file-search names (config-dir))))
 
 (fn file-readable? [path]
-  (= 1 (nvim.fn.filereadable path)))
+  (= 1 (vim.fn.filereadable path)))
 
 (fn resolve-relative-to [path root]
   "Successively remove parts of the path until we get to a relative path that
@@ -112,7 +110,7 @@
 
 (fn current-source []
   (let [info (debug.getinfo 2 "S")]
-    (when (text.starts-with (a.get info :source) "@")
+    (when (vim.startswith (a.get info :source) "@")
       (string.sub info.source 2))))
 
 (local conjure-source-directory
@@ -125,10 +123,10 @@
   (when file-path
     (a.some
       (fn [mod-name]
-        (let [mod-path (string.gsub mod-name "%." afs.path-sep)]
+        (let [mod-path (string.gsub mod-name "%." path-sep)]
           (when (or
-                  (text.ends-with file-path (.. mod-path ".fnl"))
-                  (text.ends-with file-path (.. mod-path "/init.fnl")))
+                  (vim.endswith file-path (.. mod-path ".fnl"))
+                  (vim.endswith file-path (.. mod-path "/init.fnl")))
             mod-name)))
       (a.keys package.loaded))))
 

--- a/plugin/conjure.lua
+++ b/plugin/conjure.lua
@@ -1,0 +1,5 @@
+if vim.fn.has("nvim-0.8") == 1 then
+  require("conjure.main").main()
+else
+  vim.notify_once("Conjure requires Neovim > v0.8", vim.log.levels.ERROR)
+end

--- a/plugin/conjure.vim
+++ b/plugin/conjure.vim
@@ -1,5 +1,0 @@
-if has("nvim-0.7")
-  lua require("conjure.main").main()
-else
-  echoerr "Conjure requires Neovim > v0.7"
-endif


### PR DESCRIPTION
Hi,
I've seen that in the README was stated that Conjure works with neovim 0.7 or above. I've found in `fs.fnl` that `vim.fse.normalize` is been used, witch is a nvim 0.8+ feature so I've updated the minimum version required in the README and `plugin/conjure.vim`. With this version bump we unlock a lot of functionality that can replace some of the old batteries that were created.

I've also took the liberty to convert the `plugin/conjure.vim` to lua so we can use `vim.notify` instead of `echoerr`. `vim.notify` can integrate with other plugins and change the displaying of notifications (see example [noice.nvim](https://github.com/folke/noice.nvim))