### PR TITLE
fix fennel client ,reload file error, nvim is nil

### DIFF
--- a/fnl/conjure/client/fennel/stdio.fnl
+++ b/fnl/conjure/client/fennel/stdio.fnl
@@ -9,6 +9,7 @@
 (local client (autoload :conjure.client))
 (local log (autoload :conjure.log))
 (local ts (autoload :conjure.tree-sitter))
+(local nvim (autoload :conjure.aniseed.nvim))
 
 (config.merge
   {:client


### PR DESCRIPTION
using conjure with fennel file through an stdio REPL,  conjure  throws error after calling ,reload file command, error msg listed below.


E5108: Error executing lua: Vim:Error executing Lua callback: ...re/nvim/lazy/conjure/lua/conjure/client/fennel/stdio.lua:72: attempt to index global 'nvim' (a nil value)
stack traceback:
	...re/nvim/lazy/conjure/lua/conjure/client/fennel/stdio.lua:72: in function <...re/nvim/lazy/conjure/lua/conjure/client/fennel/stdio.lua:71>
	[C]: at 0x010249ae44
stack traceback:
	[C]: at 0x010249ae44
