### PR TITLE
Refactor treesitter.fnl to remove aniseed nvim module

### DIFF
--- a/fnl/conjure/tree-sitter.fnl
+++ b/fnl/conjure/tree-sitter.fnl
@@ -1,6 +1,5 @@
 (local {: autoload} (require :nfnl.module))
 (local a (autoload :nfnl.core))
-(local nvim (autoload :conjure.aniseed.nvim))
 (local client (autoload :conjure.client))
 (local config (autoload :conjure.config))
 (local text (autoload :conjure.text))
@@ -37,8 +36,8 @@
   new lines."
   (when node
     (if vim.treesitter.get_node_text
-      (vim.treesitter.get_node_text node (nvim.get_current_buf))
-      (vim.treesitter.query.get_node_text node (nvim.get_current_buf)))))
+      (vim.treesitter.get_node_text node (vim.api.nvim_get_current_buf))
+      (vim.treesitter.query.get_node_text node (vim.api.nvim_get_current_buf)))))
 
 (fn lisp-comment-node? [node]
   "Node is a (comment ...) form"
@@ -119,8 +118,8 @@
           (config.get-in [:extract :form_pairs]))
         (a.some
           (fn [[start end]]
-            (and (text.starts-with node-str start)
-                 (text.ends-with node-str end)))
+            (and (vim.startswith node-str start)
+                 (vim.endswith node-str end)))
           extra-pairs)
         false)))
 
@@ -128,7 +127,7 @@
   (let [node-str (node->str node)]
     (or (a.some
           (fn [prefix]
-            (text.starts-with node-str prefix))
+            (vim.startswith node-str prefix))
           prefixes)
         false)))
 

--- a/lua/conjure/tree-sitter.lua
+++ b/lua/conjure/tree-sitter.lua
@@ -2,7 +2,6 @@
 local _local_1_ = require("nfnl.module")
 local autoload = _local_1_["autoload"]
 local a = autoload("nfnl.core")
-local nvim = autoload("conjure.aniseed.nvim")
 local client = autoload("conjure.client")
 local config = autoload("conjure.config")
 local text = autoload("conjure.text")
@@ -42,9 +41,9 @@ end
 local function node__3estr(node)
   if node then
     if vim.treesitter.get_node_text then
-      return vim.treesitter.get_node_text(node, nvim.get_current_buf())
+      return vim.treesitter.get_node_text(node, vim.api.nvim_get_current_buf())
     else
-      return vim.treesitter.query.get_node_text(node, nvim.get_current_buf())
+      return vim.treesitter.query.get_node_text(node, vim.api.nvim_get_current_buf())
     end
   else
     return nil
@@ -134,7 +133,7 @@ local function node_surrounded_by_form_pair_chars_3f(node, extra_pairs)
     local function _21_(_20_)
       local start = _20_[1]
       local _end = _20_[2]
-      return (text["starts-with"](node_str, start) and text["ends-with"](node_str, _end))
+      return (vim.startswith(node_str, start) and vim.endswith(node_str, _end))
     end
     or_19_ = a.some(_21_, extra_pairs)
   end
@@ -143,7 +142,7 @@ end
 local function node_prefixed_by_chars_3f(node, prefixes)
   local node_str = node__3estr(node)
   local function _22_(prefix)
-    return text["starts-with"](node_str, prefix)
+    return vim.startswith(node_str, prefix)
   end
   return (a.some(_22_, prefixes) or false)
 end


### PR DESCRIPTION
Hi,
this PR refactors treesitter.fnl to use neovim builtin api instead of using aniseed nvim module.