### PR TITLE
Add missing keymaps for Rust client

### DIFF
--- a/fnl/conjure/client/rust/evcxr.fnl
+++ b/fnl/conjure/client/rust/evcxr.fnl
@@ -3,6 +3,7 @@
 (local client (autoload :conjure.client))
 (local config (autoload :conjure.config))
 (local log (autoload :conjure.log))
+(local mapping (autoload :conjure.mapping))
 (local stdio (autoload :conjure.remote.stdio))
 (local str (autoload :conjure.aniseed.string))
 
@@ -123,8 +124,8 @@
 (fn interrupt []
   (with-repl-or-warn
     (fn [repl]
-      (let [uv vim.loop]
-        (uv.kill repl.pid uv.constants.SIGINT)))))
+      (log.append [(.. comment-prefix " Sending interrupt signal.")] {:break? true})
+      (repl.send-signal vim.loop.constants.SIGINT))))
 
 ; Eval
 
@@ -143,12 +144,29 @@
 (fn eval-file [opts]
   (eval-str (a.assoc opts :code (a.slurp opts.file-path))))
 
+(fn on-filetype []
+  (mapping.buf
+    :RustStart (cfg [:mapping :start])
+    start
+    {:desc "Start the Rust REPL"})
+
+  (mapping.buf
+    :RustStop (cfg [:mapping :stop])
+    stop
+    {:desc "Stop the Rust REPL"})
+
+  (mapping.buf
+    :RustInterrupt (cfg [:mapping :interrupt])
+    interrupt
+    {:desc "Interrupt the current evaluation"}))
+
 {: buf-suffix
  : comment-prefix
- : stop
- : start
- : on-load
- : on-exit
- : interrupt
+ : eval-file
  : eval-str
- : eval-file}
+ : interrupt
+ : on-exit
+ : on-filetype
+ : on-load
+ : start
+ : stop}

--- a/lua/conjure/client/rust/evcxr.lua
+++ b/lua/conjure/client/rust/evcxr.lua
@@ -5,6 +5,7 @@ local a = autoload("conjure.aniseed.core")
 local client = autoload("conjure.client")
 local config = autoload("conjure.config")
 local log = autoload("conjure.log")
+local mapping = autoload("conjure.mapping")
 local stdio = autoload("conjure.remote.stdio")
 local str = autoload("conjure.aniseed.string")
 local buf_suffix = ".rs"
@@ -113,8 +114,8 @@ local function on_exit()
 end
 local function interrupt()
   local function _20_(repl)
-    local uv = vim.loop
-    return uv.kill(repl.pid, uv.constants.SIGINT)
+    log.append({(comment_prefix .. " Sending interrupt signal.")}, {["break?"] = true})
+    return repl["send-signal"](vim.loop.constants.SIGINT)
   end
   return with_repl_or_warn(_20_)
 end
@@ -136,4 +137,9 @@ end
 local function eval_file(opts)
   return eval_str(a.assoc(opts, "code", a.slurp(opts["file-path"])))
 end
-return {["buf-suffix"] = buf_suffix, ["comment-prefix"] = comment_prefix, stop = stop, start = start, ["on-load"] = on_load, ["on-exit"] = on_exit, interrupt = interrupt, ["eval-str"] = eval_str, ["eval-file"] = eval_file}
+local function on_filetype()
+  mapping.buf("RustStart", cfg({"mapping", "start"}), start, {desc = "Start the Rust REPL"})
+  mapping.buf("RustStop", cfg({"mapping", "stop"}), stop, {desc = "Stop the Rust REPL"})
+  return mapping.buf("RustInterrupt", cfg({"mapping", "interrupt"}), interrupt, {desc = "Interrupt the current evaluation"})
+end
+return {["buf-suffix"] = buf_suffix, ["comment-prefix"] = comment_prefix, ["eval-file"] = eval_file, ["eval-str"] = eval_str, interrupt = interrupt, ["on-exit"] = on_exit, ["on-filetype"] = on_filetype, ["on-load"] = on_load, start = start, stop = stop}


### PR DESCRIPTION
This should fix issue #646.
- Added `on-filetype` function to add keymapping to start, stop, and interrupt the Rust REPL.

These changes will hopefully help future contributors or the curious understand the code base quicker.
- Replaced code for the `interrupt` function with equivalent code from the other stdio-based clients (hy, julia, python, racket, scheme, snd-s7, and sql).
- Sorted functions exported.
