### PR TITLE
Improve selection of forms for Rust client

### DIFF
--- a/dev/rust/sandbox.rs
+++ b/dev/rust/sandbox.rs
@@ -1,11 +1,16 @@
-// evaluate this root form
+// Examples from "Evcxr common usage information".
+//   - https://github.com/evcxr/evcxr/blob/main/COMMON.md
+
+// With the cursor on the word, pub, evaluate form works.
 pub struct User {
     username: String
 }
+
 let user = User { username: String::from("John Doe") };
 println!("{}", user.username);
 
-// select and evaluate this:
+// The REPL will accept commands that are not legal Rust statements.
+// Select and evaluate this to load the rand crate from crates.io:
 // :dep rand = { version = "0.7.3" }
 let rand_x: u8 = rand::random();
 println!("{}", rand_x);
@@ -15,8 +20,17 @@ let err_x = unknown();
 
 let x = 0;
 let y = 1;
-// select and evaluate this:
+// Select and evaluate this to see what variables have been defined:
 // :vars
-//
+
 let all_values = vec![10, 20, 30, 40, 50];
+//  This line with a semi-colon produces an error. Without the semi-colon, it's syntactically OK.
+//  To verify this, make a selection and evaluate it.
+//  With a form-node? function defined for the Rust client, we can evaluate the line
+//  when the cursor is anywhere on the line except on the semi-colon. This sends the line without
+//  the semi-colon.
 all_values[2..3];
+
+// This is an error because he variable `some_values` contains a reference with a non-static
+// lifetime and can't be persisted.
+let some_values = &all_values[2..3];

--- a/fnl/conjure/client/rust/evcxr.fnl
+++ b/fnl/conjure/client/rust/evcxr.fnl
@@ -29,6 +29,23 @@
 (local cfg (config.get-in-fn [:client :rust :evcxr]))
 (local state (client.new-state #(do {:repl nil})))
 
+;; These types of nodes for Rust are roughly equivalent to Lisp forms.
+;;   struct_item
+;;   let_declaration
+;;   expression_statement
+;;   struct_item
+;;   index_expression
+(fn form-node?
+  [node]
+  (log.dbg "form-node?: node:type =" (node:type))
+  (log.dbg "form-node?: node:parent =" (node:parent))
+  (let [parent (node:parent)]
+    (if (= "struct_item" (node:type)) true
+        (= "let_declaration" (node:type)) true
+        (= "index_expression" (node:type)) true
+        (= "expression_statement" (node:type)) true
+        false)))
+
 (fn with-repl-or-warn [f opts]
   (let [repl (state :repl)]
     (if repl
@@ -164,6 +181,7 @@
  : comment-prefix
  : eval-file
  : eval-str
+ : form-node?
  : interrupt
  : on-exit
  : on-filetype

--- a/lua/conjure/client/rust/evcxr.lua
+++ b/lua/conjure/client/rust/evcxr.lua
@@ -21,6 +21,22 @@ local function _3_()
   return {repl = nil}
 end
 state = client["new-state"](_3_)
+local function form_node_3f(node)
+  log.dbg("form-node?: node:type =", node:type())
+  log.dbg("form-node?: node:parent =", node:parent())
+  local parent = node:parent()
+  if ("struct_item" == node:type()) then
+    return true
+  elseif ("let_declaration" == node:type()) then
+    return true
+  elseif ("index_expression" == node:type()) then
+    return true
+  elseif ("expression_statement" == node:type()) then
+    return true
+  else
+    return false
+  end
+end
 local function with_repl_or_warn(f, opts)
   local repl = state("repl")
   if repl then
@@ -38,25 +54,25 @@ local function display_repl_status(status)
   end
 end
 local function display_result(msg)
-  local function _6_(_241)
+  local function _7_(_241)
     return (comment_prefix .. _241)
   end
-  return log.append(a.map(_6_, msg))
+  return log.append(a.map(_7_, msg))
 end
 local function format_msg(msg)
-  local function _7_(_241)
+  local function _8_(_241)
     return not ("()" == _241)
   end
-  local function _8_(_241)
+  local function _9_(_241)
     return not ("" == _241)
   end
-  return a.filter(_7_, a.filter(_8_, str.split(msg, "\n")))
+  return a.filter(_8_, a.filter(_9_, str.split(msg, "\n")))
 end
 local function unbatch(msgs)
-  local function _9_(_241)
+  local function _10_(_241)
     return (a.get(_241, "out") or a.get(_241, "err"))
   end
-  return str.join("", a.map(_9_, msgs))
+  return str.join("", a.map(_10_, msgs))
 end
 local function prep_code(s)
   return (s .. "\n")
@@ -75,21 +91,21 @@ local function start()
   if state("repl") then
     return log.append({(comment_prefix .. "Can't start, REPL is already running."), (comment_prefix .. "Stop the REPL with " .. config["get-in"]({"mapping", "prefix"}) .. cfg({"mapping", "stop"}))}, {["break?"] = true})
   else
-    local function _11_()
+    local function _12_()
       display_repl_status("started")
-      local function _12_(repl)
-        local function _13_(msgs)
+      local function _13_(repl)
+        local function _14_(msgs)
           return display_result(format_msg(unbatch(msgs)))
         end
-        return repl.send(prep_code(":help"), _13_, {["batch?"] = true})
+        return repl.send(prep_code(":help"), _14_, {["batch?"] = true})
       end
-      return with_repl_or_warn(_12_)
+      return with_repl_or_warn(_13_)
     end
-    local function _14_(err)
+    local function _15_(err)
       log.append({"error"})
       return display_repl_status(err)
     end
-    local function _15_(code, signal)
+    local function _16_(code, signal)
       if (("number" == type(code)) and (code > 0)) then
         log.append({(comment_prefix .. "process exited with code " .. code)})
       else
@@ -100,10 +116,10 @@ local function start()
       end
       return stop()
     end
-    local function _18_(msg)
+    local function _19_(msg)
       return display_result(format_msg(unbatch({msg})), {["join-first?"] = true})
     end
-    return a.assoc(state(), "repl", stdio.start({["prompt-pattern"] = cfg({"prompt_pattern"}), cmd = cfg({"command"}), ["on-success"] = _11_, ["on-error"] = _14_, ["on-exit"] = _15_, ["on-stray-output"] = _18_}))
+    return a.assoc(state(), "repl", stdio.start({["prompt-pattern"] = cfg({"prompt_pattern"}), cmd = cfg({"command"}), ["on-success"] = _12_, ["on-error"] = _15_, ["on-exit"] = _16_, ["on-stray-output"] = _19_}))
   end
 end
 local function on_load()
@@ -113,15 +129,15 @@ local function on_exit()
   return stop()
 end
 local function interrupt()
-  local function _20_(repl)
+  local function _21_(repl)
     log.append({(comment_prefix .. " Sending interrupt signal.")}, {["break?"] = true})
     return repl["send-signal"](vim.loop.constants.SIGINT)
   end
-  return with_repl_or_warn(_20_)
+  return with_repl_or_warn(_21_)
 end
 local function eval_str(opts)
-  local function _21_(repl)
-    local function _22_(msgs)
+  local function _22_(repl)
+    local function _23_(msgs)
       local msgs0 = format_msg(unbatch(msgs))
       display_result(msgs0)
       if opts["on-result"] then
@@ -130,9 +146,9 @@ local function eval_str(opts)
         return nil
       end
     end
-    return repl.send(prep_code(opts.code), _22_, {["batch?"] = true})
+    return repl.send(prep_code(opts.code), _23_, {["batch?"] = true})
   end
-  return with_repl_or_warn(_21_)
+  return with_repl_or_warn(_22_)
 end
 local function eval_file(opts)
   return eval_str(a.assoc(opts, "code", a.slurp(opts["file-path"])))
@@ -142,4 +158,4 @@ local function on_filetype()
   mapping.buf("RustStop", cfg({"mapping", "stop"}), stop, {desc = "Stop the Rust REPL"})
   return mapping.buf("RustInterrupt", cfg({"mapping", "interrupt"}), interrupt, {desc = "Interrupt the current evaluation"})
 end
-return {["buf-suffix"] = buf_suffix, ["comment-prefix"] = comment_prefix, ["eval-file"] = eval_file, ["eval-str"] = eval_str, interrupt = interrupt, ["on-exit"] = on_exit, ["on-filetype"] = on_filetype, ["on-load"] = on_load, start = start, stop = stop}
+return {["buf-suffix"] = buf_suffix, ["comment-prefix"] = comment_prefix, ["eval-file"] = eval_file, ["eval-str"] = eval_str, ["form-node?"] = form_node_3f, interrupt = interrupt, ["on-exit"] = on_exit, ["on-filetype"] = on_filetype, ["on-load"] = on_load, start = start, stop = stop}


### PR DESCRIPTION
The addition of a `form-node?` function to the Rust client should make it more convenient to put your cursor on a line and evaluate statements or expressions.

The `dev/rust/sandbox.rs` has more comments to clarify how to evaluating things. I've included a link to the [Evcxr common usage information](https://github.com/evcxr/evcxr/blob/main/COMMON.md) document to help those not very familiar with Rust and `evcxr`.