### PR TITLE
Add client-name to clone op

### DIFF
--- a/fnl/conjure/client/clojure/nrepl/server.fnl
+++ b/fnl/conjure/client/clojure/nrepl/server.fnl
@@ -212,7 +212,8 @@
 (fn clone-session [session]
   (send
     {:op :clone
-     :session (a.get session :id)}
+     :session (a.get session :id)
+     :client-name "Conjure"}
     (nrepl.with-all-msgs-fn
       (fn [msgs]
         (let [session-id (a.some #(a.get $1 :new-session) msgs)]


### PR DESCRIPTION
As discussed [here](https://clojurians.slack.com/archives/C17JYSA3H/p1744123473420459), we are adding nREPL client information to be able to provide metrics about the client of the nREPL.

Related to https://github.com/nrepl/nrepl/pull/370