### PR TITLE
Fix unknown-module-field for vim.loop.constants.SIGINT

### DIFF
--- a/fnl/conjure/client/hy/stdio.fnl
+++ b/fnl/conjure/client/hy/stdio.fnl
@@ -158,7 +158,7 @@
   (with-repl-or-warn
     (fn [repl]
       (log.append [(.. comment-prefix " Sending interrupt signal.")] {:break? true})
-      (repl.send-signal vim.loop.constants.SIGINT))))
+      (repl.send-signal :sigint))))
 
 (fn on-filetype []
   (mapping.buf

--- a/fnl/conjure/client/julia/stdio.fnl
+++ b/fnl/conjure/client/julia/stdio.fnl
@@ -168,7 +168,7 @@
   (with-repl-or-warn
     (fn [repl]
       (log.append [(.. comment-prefix " Sending interrupt signal.")] {:break? true})
-      (repl.send-signal vim.loop.constants.SIGINT))))
+      (repl.send-signal :sigint))))
 
 (fn on-filetype []
   (mapping.buf

--- a/fnl/conjure/client/python/stdio.fnl
+++ b/fnl/conjure/client/python/stdio.fnl
@@ -272,7 +272,7 @@
   (with-repl-or-warn
     (fn [repl]
       (log.append [(.. comment-prefix " Sending interrupt signal.")] {:break? true})
-      (repl.send-signal vim.loop.constants.SIGINT))))
+      (repl.send-signal :signal))))
 
 (fn on-load []
   ;; Start up REPL only if g.conjure#client_on_load is v:true.

--- a/fnl/conjure/client/python/stdio.fnl
+++ b/fnl/conjure/client/python/stdio.fnl
@@ -272,7 +272,7 @@
   (with-repl-or-warn
     (fn [repl]
       (log.append [(.. comment-prefix " Sending interrupt signal.")] {:break? true})
-      (repl.send-signal :signal))))
+      (repl.send-signal :sigint))))
 
 (fn on-load []
   ;; Start up REPL only if g.conjure#client_on_load is v:true.

--- a/fnl/conjure/client/racket/stdio.fnl
+++ b/fnl/conjure/client/racket/stdio.fnl
@@ -81,7 +81,7 @@
   (with-repl-or-warn
     (fn [repl]
       (log.append [(.. comment-prefix " Sending interrupt signal.")] {:break? true})
-      (repl.send-signal vim.loop.constants.SIGINT))))
+      (repl.send-signal :sigint))))
 
 (fn eval-file [opts]
   (eval-str (a.assoc opts :code (.. ",require-reloadable " opts.file-path))))

--- a/fnl/conjure/client/scheme/stdio.fnl
+++ b/fnl/conjure/client/scheme/stdio.fnl
@@ -127,7 +127,7 @@
   (with-repl-or-warn
     (fn [repl]
       (log.append [(.. comment-prefix " Sending interrupt signal.")] {:break? true})
-      (repl.send-signal vim.loop.constants.SIGINT))))
+      (repl.send-signal :sigint))))
 
 (fn on-load []
   (start))

--- a/fnl/conjure/client/snd-s7/stdio.fnl
+++ b/fnl/conjure/client/snd-s7/stdio.fnl
@@ -91,7 +91,7 @@
   (with-repl-or-warn
     (fn [repl]
       (log.append [(.. comment-prefix " Sending interrupt signal.")] {:break? true})
-      (repl.send-signal vim.loop.constants.SIGINT))))
+      (repl.send-signal :sigint))))
 
 (fn display-repl-status [status]
   (log.append

--- a/fnl/conjure/client/sql/stdio.fnl
+++ b/fnl/conjure/client/sql/stdio.fnl
@@ -133,7 +133,7 @@
   (with-repl-or-warn
     (fn [repl]
       (log.append [(.. comment-prefix " Sending interrupt signal.")] {:break? true})
-      (repl.send-signal vim.loop.constants.SIGINT))))
+      (repl.send-signal :sigint))))
 
 (fn display-repl-status [status]
   (let [repl (state :repl)]

--- a/lua/conjure/client/hy/stdio.lua
+++ b/lua/conjure/client/hy/stdio.lua
@@ -169,7 +169,7 @@ local function interrupt()
   log.dbg("sending interrupt message", "")
   local function _30_(repl)
     log.append({(comment_prefix .. " Sending interrupt signal.")}, {["break?"] = true})
-    return repl["send-signal"](vim.loop.constants.SIGINT)
+    return repl["send-signal"]("sigint")
   end
   return with_repl_or_warn(_30_)
 end

--- a/lua/conjure/client/julia/stdio.lua
+++ b/lua/conjure/client/julia/stdio.lua
@@ -141,7 +141,7 @@ end
 local function interrupt()
   local function _23_(repl)
     log.append({(comment_prefix .. " Sending interrupt signal.")}, {["break?"] = true})
-    return repl["send-signal"](vim.loop.constants.SIGINT)
+    return repl["send-signal"]("sigint")
   end
   return with_repl_or_warn(_23_)
 end

--- a/lua/conjure/client/python/stdio.lua
+++ b/lua/conjure/client/python/stdio.lua
@@ -223,7 +223,7 @@ end
 local function interrupt()
   local function _32_(repl)
     log.append({(comment_prefix .. " Sending interrupt signal.")}, {["break?"] = true})
-    return repl["send-signal"](vim.loop.constants.SIGINT)
+    return repl["send-signal"]("signal")
   end
   return with_repl_or_warn(_32_)
 end

--- a/lua/conjure/client/python/stdio.lua
+++ b/lua/conjure/client/python/stdio.lua
@@ -223,7 +223,7 @@ end
 local function interrupt()
   local function _32_(repl)
     log.append({(comment_prefix .. " Sending interrupt signal.")}, {["break?"] = true})
-    return repl["send-signal"]("signal")
+    return repl["send-signal"]("sigint")
   end
   return with_repl_or_warn(_32_)
 end

--- a/lua/conjure/client/racket/stdio.lua
+++ b/lua/conjure/client/racket/stdio.lua
@@ -71,7 +71,7 @@ end
 local function interrupt()
   local function _10_(repl)
     log.append({(comment_prefix .. " Sending interrupt signal.")}, {["break?"] = true})
-    return repl["send-signal"](vim.loop.constants.SIGINT)
+    return repl["send-signal"]("sigint")
   end
   return with_repl_or_warn(_10_)
 end

--- a/lua/conjure/client/scheme/stdio.lua
+++ b/lua/conjure/client/scheme/stdio.lua
@@ -110,7 +110,7 @@ end
 local function interrupt()
   local function _19_(repl)
     log.append({(comment_prefix .. " Sending interrupt signal.")}, {["break?"] = true})
-    return repl["send-signal"](vim.loop.constants.SIGINT)
+    return repl["send-signal"]("sigint")
   end
   return with_repl_or_warn(_19_)
 end

--- a/lua/conjure/client/snd-s7/stdio.lua
+++ b/lua/conjure/client/snd-s7/stdio.lua
@@ -71,7 +71,7 @@ end
 local function interrupt()
   local function _10_(repl)
     log.append({(comment_prefix .. " Sending interrupt signal.")}, {["break?"] = true})
-    return repl["send-signal"](vim.loop.constants.SIGINT)
+    return repl["send-signal"]("sigint")
   end
   return with_repl_or_warn(_10_)
 end

--- a/lua/conjure/client/sql/stdio.lua
+++ b/lua/conjure/client/sql/stdio.lua
@@ -97,7 +97,7 @@ end
 local function interrupt()
   local function _13_(repl)
     log.append({(comment_prefix .. " Sending interrupt signal.")}, {["break?"] = true})
-    return repl["send-signal"](vim.loop.constants.SIGINT)
+    return repl["send-signal"]("sigint")
   end
   return with_repl_or_warn(_13_)
 end


### PR DESCRIPTION
This is a minor fix to quiet the diagnostics from the `fennel-ls` language server when working with the `stdio`-based Conjure clients.

Just tidying this a bit so feel free to reject this PR.