### PR TITLE
Make it possible to turn off clojure.test failure pretty printing

### DIFF
--- a/doc/conjure-client-clojure-nrepl.txt
+++ b/doc/conjure-client-clojure-nrepl.txt
@@ -313,6 +313,12 @@ All configuration can be set as described in |conjure-configuration|.
             current root form is a test that should be ran.
             Default: `["deftest"]`
 
+                      *g:conjure#client#clojure#nrepl#test#pretty_print_test_failures*
+`g:conjure#client#clojure#nrepl#test#pretty_print_test_failures
+            Pretty print a diff of the test's expected and
+            actual data-structures.
+            Default: `true`
+
                                   *g:conjure#client#clojure#nrepl#test#runner*
 `g:conjure#client#clojure#nrepl#test#runner`
             Test runner to use for the various test mappings. The following

--- a/fnl/conjure/client/clojure/nrepl/init.fnl
+++ b/fnl/conjure/client/clojure/nrepl/init.fnl
@@ -73,6 +73,7 @@
 
       :test
       {:current_form_names ["deftest"]
+       :pretty_print_test_failures true
        :raw_out false
        :runner "clojure"
        :call_suffix nil}

--- a/fnl/conjure/client/clojure/nrepl/server.fnl
+++ b/fnl/conjure/client/clojure/nrepl/server.fnl
@@ -230,71 +230,73 @@
         (assume-session (a.first sessions))))))
 
 (fn eval-preamble [cb]
-  (let [queue-size (config.get-in [:client :clojure :nrepl :tap :queue_size])]
+  (let [queue-size (config.get-in [:client :clojure :nrepl :tap :queue_size])
+        pretty-print-test-failures? (config.get-in [:client :clojure :nrepl :test :pretty_print_test_failures])]
     (send
       {:op :eval
        :code (str.join
                "\n"
-               ["(create-ns 'conjure.internal)"
-                 "(intern 'conjure.internal 'initial-ns (symbol (str *ns*)))"
+               (a.concat
+                 ["(create-ns 'conjure.internal)"
+                   "(intern 'conjure.internal 'initial-ns (symbol (str *ns*)))"
 
-                 "(ns conjure.internal"
-                 "  (:require [clojure.pprint :as pp] [clojure.test] [clojure.data] [clojure.string]))"
+                   "(ns conjure.internal"
+                   "  (:require [clojure.pprint :as pp] [clojure.test] [clojure.data] [clojure.string]))"
 
-                 ;; This is a shim that inserts a pprint fn in the place that CIDER would create it if it's not found.
-                 ;; We shim instead of creating our own distinct function because babashka requires us
-                 ;; to refer to `cider.nrepl.pprint/pprint` if we want to use pretty printing.
-                 ;; https://github.com/Olical/conjure/issues/406
-                 "(when-not (find-ns 'cider.nrepl.pprint)"
-                 "  (create-ns 'cider.nrepl.pprint)"
-                 "  (intern 'cider.nrepl.pprint 'pprint"
-                 "    (fn pprint [val w opts]"
-                 "      (apply pp/write val"
-                 "        (mapcat identity (assoc opts :stream w))))))"
+                   ;; This is a shim that inserts a pprint fn in the place that CIDER would create it if it's not found.
+                   ;; We shim instead of creating our own distinct function because babashka requires us
+                   ;; to refer to `cider.nrepl.pprint/pprint` if we want to use pretty printing.
+                   ;; https://github.com/Olical/conjure/issues/406
+                   "(when-not (find-ns 'cider.nrepl.pprint)"
+                   "  (create-ns 'cider.nrepl.pprint)"
+                   "  (intern 'cider.nrepl.pprint 'pprint"
+                   "    (fn pprint [val w opts]"
+                   "      (apply pp/write val"
+                   "        (mapcat identity (assoc opts :stream w))))))"
 
-                 "(defn bounded-conj [queue x limit]"
-                 "  (->> x (conj queue) (take limit)))"
+                   "(defn bounded-conj [queue x limit]"
+                   "  (->> x (conj queue) (take limit)))"
 
-                 (.. "(def tap-queue-size " queue-size ")")
-                 "(defonce tap-queue! (atom (list)))"
+                   (.. "(def tap-queue-size " queue-size ")")
+                   "(defonce tap-queue! (atom (list)))"
 
-                 ;; Must be a defonce so that we always have the same function
-                 ;; reference to remove-tap and add-tap. If we make a new
-                 ;; function each time we'll end up adding more and more tap
-                 ;; functions.
-                 "(defonce enqueue-tap!"
-                 "  (fn [x] (swap! tap-queue! bounded-conj x tap-queue-size)))"
+                   ;; Must be a defonce so that we always have the same function
+                   ;; reference to remove-tap and add-tap. If we make a new
+                   ;; function each time we'll end up adding more and more tap
+                   ;; functions.
+                   "(defonce enqueue-tap!"
+                   "  (fn [x] (swap! tap-queue! bounded-conj x tap-queue-size)))"
 
-                 ;; No setup for older Clojure versions.
-                 "(when (resolve 'add-tap)"
-                 "  (remove-tap enqueue-tap!)"
-                 "  (add-tap enqueue-tap!))"
+                   ;; No setup for older Clojure versions.
+                   "(when (resolve 'add-tap)"
+                   "  (remove-tap enqueue-tap!)"
+                   "  (add-tap enqueue-tap!))"
 
-                 "(defn dump-tap-queue! []"
-                 "  (reverse (first (reset-vals! tap-queue! (list)))))"
+                   "(defn dump-tap-queue! []"
+                   "  (reverse (first (reset-vals! tap-queue! (list)))))"]
+                 (when pretty-print-test-failures?
+                   ["(defmethod clojure.test/report :fail [m]"
+                    "  (clojure.test/with-test-out"
+                    "    (clojure.test/inc-report-counter :fail)"
+                    "    (println \"\nFAIL in\" (clojure.test/testing-vars-str m))"
+                    "    (when (seq clojure.test/*testing-contexts*) (println (clojure.test/testing-contexts-str)))"
+                    "    (when-let [message (:message m)] (println message))"
+                    "    (print \"expected:\" (with-out-str (prn (:expected m))))"
+                    "    (print \"  actual:\" (with-out-str (prn (:actual m))))"
+                    "    (when (and (seq? (:actual m))"
+                    "               (= #'clojure.core/not (resolve (first (:actual m))))"
+                    "               (seq? (second (:actual m)))"
+                    "               (= #'clojure.core/= (resolve (first (second (:actual m)))))"
+                    "               (= 3 (count (second (:actual m)))))"
+                    "      (let [[missing extra _] (clojure.data/diff (second (second (:actual m))) (last (second (:actual m))))"
+                    "            missing-str (with-out-str (pp/pprint missing))"
+                    "            missing-lines (clojure.string/split-lines missing-str)"
+                    "            extra-str (with-out-str (pp/pprint extra))"
+                    "            extra-lines (clojure.string/split-lines extra-str)]"
+                    "        (when (some? missing) (doseq [m missing-lines] (println \"- \" m)))"
+                    "        (when (some? extra) (doseq [e extra-lines] (println \"+ \" e)))))))"])
 
-                 "(defmethod clojure.test/report :fail [m]"
-                 "  (clojure.test/with-test-out"
-                 "    (clojure.test/inc-report-counter :fail)"
-                 "    (println \"\nFAIL in\" (clojure.test/testing-vars-str m))"
-                 "    (when (seq clojure.test/*testing-contexts*) (println (clojure.test/testing-contexts-str)))"
-                 "    (when-let [message (:message m)] (println message))"
-                 "    (print \"expected:\" (with-out-str (prn (:expected m))))"
-                 "    (print \"  actual:\" (with-out-str (prn (:actual m))))"
-                 "    (when (and (seq? (:actual m))"
-                 "               (= #'clojure.core/not (resolve (first (:actual m))))"
-                 "               (seq? (second (:actual m)))"
-                 "               (= #'clojure.core/= (resolve (first (second (:actual m)))))"
-                 "               (= 3 (count (second (:actual m)))))"
-                 "      (let [[missing extra _] (clojure.data/diff (second (second (:actual m))) (last (second (:actual m))))"
-                 "            missing-str (with-out-str (pp/pprint missing))"
-                 "            missing-lines (clojure.string/split-lines missing-str)"
-                 "            extra-str (with-out-str (pp/pprint extra))"
-                 "            extra-lines (clojure.string/split-lines extra-str)]"
-                 "        (when (some? missing) (doseq [m missing-lines] (println \"- \" m)))"
-                 "        (when (some? extra) (doseq [e extra-lines] (println \"+ \" e)))))))"
-
-                 "(in-ns initial-ns)"])}
+                   ["(in-ns initial-ns)"]))}
       (when cb
         (nrepl.with-all-msgs-fn cb)))))
 


### PR DESCRIPTION
In some clojure codebases/test setups it is useful to setup custom clojure.test reporting methods, like:

```clojure
(defmethod clojure.test/report :fail [m]
  ;; whatever custom reporting code
  )
```

But since https://github.com/Olical/conjure/pull/569, Conjure might override those, depending on if the nrepl connection is established before or after the codebase's custom clojure.test reporting methods are registered.
And you get conjure's version even in the presence of your own override:

```clojure
(get (methods t/report) :fail)
;; => #function[conjure.internal/eval127846/fn--127847]
```

Thus I figured it would be nice to be able to turn off conjure's registration of the `clojure.test/report` via a config flag.

This PR introduces a new config `:clojure :nrepl :test :pretty_print_test_failures` config field that defaults to true but can be set to false if needed

Somehow even with these changes and setting the new flag to false (`(set nvim.g.conjure#client#clojure#nrepl#test#pretty_print_test_failures false)`) I still get the pretty-printing behavior. Maybe I misunderstood how to go about this.

