### PR TITLE
Initialize Guile modules in REPL for non-nil contexts

### DIFF
--- a/doc/conjure.txt
+++ b/doc/conjure.txt
@@ -1040,7 +1040,7 @@ examples: https://github.com/Olical/conjure/wiki/Client-features
 `context`
             Function(header)
             Called instead of `context-pattern` if it's not defined. Is passed
-            the first few lines of the buffer as it's only argument. You can
+            the first few lines of the buffer as its only argument. You can
             parse out the context string in any way you see fit.
             The return value is passed into later functions as `opts.context`.
 

--- a/fnl/conjure-spec/client/guile/fake-socket.fnl
+++ b/fnl/conjure-spec/client/guile/fake-socket.fnl
@@ -1,0 +1,10 @@
+(var fake-repl {})
+
+(fn set-fake-repl [repl]
+  (set fake-repl repl))
+
+(fn start []
+  fake-repl)
+
+{: start
+ : set-fake-repl}

--- a/fnl/conjure-spec/client/guile/socket_spec.fnl
+++ b/fnl/conjure-spec/client/guile/socket_spec.fnl
@@ -1,0 +1,108 @@
+(local {: describe : it : spy} (require :plenary.busted))
+(local assert (require :luassert.assert))
+(local guile (require :conjure.client.guile.socket))
+(local config (require :conjure.config))
+(local fake-socket (require :conjure-spec.client.guile.fake-socket))
+
+
+(describe "conjure.client.guile.socket"
+  (fn []
+    (tset package.loaded "conjure.remote.socket" fake-socket)
+    (describe "context extraction"
+      (fn [] 
+        (it "returns nil for hello world"
+            (fn []
+              (assert.are.equal nil (guile.context "(print \"Hello World\")"))))
+        (it "returns (my-module) for (define-module (my-module))"
+            (fn []
+              (assert.are.equal "(my-module)" (guile.context "(define-module (my-module))"))))
+        (it "returns (my-module) for (define-module\\n(my-module))"
+            (fn []
+              (assert.are.equal "(my-module)" (guile.context "(define-module\n(my-module))"))))
+         (it "returns (my-module spaces) for (define-module ( my-module  spaces   ))"
+            (fn []
+              (assert.are.equal "(my-module spaces)" (guile.context "(define-module ( my-module  spaces   ))"))))
+        (it "returns nil for ;(define-module (my-module))"
+            (fn []
+              (assert.are.equal nil (guile.context ";(define-module (my-module))"))))
+        (it "returns nil for (define-m;odule (my-module))"
+            (fn []
+              (assert.are.equal nil (guile.context "(define-m;odule (my-module))"))))
+        (it "returns (another-module) for ;\n(define-module ( another-module ))"
+            (fn []
+              (assert.are.equal "(another-module)" (guile.context ";\n(define-module ( another-module ))"))))
+        (it "returns (a-module specification) for ;\\n(define-module\\n;some comments\\n( a-module\\n; more comments\\n specification))"
+            (fn []
+              (assert.are.equal "(a-module specification)" (guile.context ";\n(define-module\n;some comments\n( a-module\n; more comments\n specification))"))))))
+
+    (describe "module initialization"
+      (fn []
+        (config.merge {:client {:guile {:socket
+                      {:pipename "fake-pipe" :host-port nil}}}})
+        (it "initializes (guile-user) when eval-str called on new repl in nil context"
+            (fn []
+              (let [
+                    calls []
+                    spy-send (fn [call] (table.insert calls call))
+                    fake-repl {:send spy-send :status nil :destroy (fn [])}
+                    expected-code "(print \"Hello world\")"]
+
+                (fake-socket.set-fake-repl fake-repl)
+                (guile.connect {})
+                (tset fake-repl :status :connected)
+                (guile.eval-str {:code expected-code :context nil})
+                (guile.disconnect)
+                (assert.are.equal ",m (guile-user)\n,import (guile)" (. calls 1))
+                (assert.are.equal (.. ",m (guile-user)\n" expected-code) (. calls 2)))))
+
+        (it "initializes (guile-user) once when eval-str called twice on repl in nil context"
+            (fn []
+              (let [
+                    calls []
+                    spy-send (fn [call] (table.insert calls call))
+                    fake-repl {:send spy-send :status nil :destroy (fn [])}
+                    expected-code "(print \"Hello second call\")"]
+
+                (fake-socket.set-fake-repl fake-repl)
+                (guile.connect {})
+                (tset fake-repl :status :connected)
+                (guile.eval-str {:code "(first-call)" :context nil})
+                (guile.eval-str {:code expected-code :context nil})
+                (guile.disconnect)
+                (assert.are.equal (.. ",m (guile-user)\n" expected-code) (. calls 3)))))
+
+        (it "initializes (guile-user) again when eval-str disconnect eval-str is called in nil context"
+            (fn []
+              (let [
+                    calls []
+                    spy-send (fn [call] (table.insert calls call))
+                    fake-repl {:send spy-send :status nil :destroy (fn [])}
+                    expected-code "(print \"Hello second call\")"]
+
+                (fake-socket.set-fake-repl fake-repl)
+                (guile.connect {})
+                (tset fake-repl :status :connected)
+                (guile.eval-str {:code "(first-call)" :context nil})
+                (guile.disconnect)
+                (guile.connect {})
+                (tset fake-repl :status :connected)
+                (guile.eval-str {:code expected-code :context nil})
+                (assert.are.equal ",m (guile-user)\n,import (guile)" (. calls 3))
+                (assert.are.equal (.. ",m (guile-user)\n" expected-code) (. calls 4)))))
+
+        (it "initializes (a-module) when eval-str in (guile-user) then eval-str in (a-module)"
+            (fn []
+              (let [
+                    calls []
+                    spy-send (fn [call] (table.insert calls call))
+                    fake-repl {:send spy-send :status nil :destroy (fn [])}
+                    expected-module "a-module"
+                    expected-code "(print \"Hello second call\")"]
+
+                (fake-socket.set-fake-repl fake-repl)
+                (guile.connect {})
+                (tset fake-repl :status :connected)
+                (guile.eval-str {:code "(first-call)" :context nil})
+                (guile.eval-str {:code expected-code :context expected-module})
+                (assert.are.equal (..  ",m " expected-module "\n,import (guile)") (. calls 3))
+                (assert.are.equal (.. ",m " expected-module "\n" expected-code) (. calls 4)))))))))

--- a/fnl/conjure/client/guile/socket.fnl
+++ b/fnl/conjure/client/guile/socket.fnl
@@ -30,6 +30,24 @@
 (local buf-suffix ".scm")
 (local comment-prefix "; ")
 (local context-pattern "%(define%-module%s+(%([%g%s]-%))")
+
+(fn strip-comments [f]
+  (string.gsub f ";.-\n" ""))
+
+(fn normalize-context [arg] 
+  (let [trimmed (str.trim arg)
+        tokens  (str.split trimmed "%s+") 
+        context (.. "(" (str.join " " tokens) ")")]
+    context))
+
+(fn context [f] 
+  (let [stripped (strip-comments f)
+        define-args (string.match stripped "%(define%-module%s+%(([%g%s]-)%)")
+        context (if define-args (normalize-context define-args) nil)]
+                              (log.append ["context" context])
+   context))
+
+
 (local form-node? ts.node-surrounded-by-form-pair-chars?)
 
 (fn with-repl-or-warn [f opts]
@@ -198,7 +216,8 @@
 {: buf-suffix
  : comment-prefix
  : connect
- : context-pattern
+ : context
+; : context-pattern
  : disconnect
  : doc-str
  : eval-file

--- a/fnl/conjure/client/guile/socket.fnl
+++ b/fnl/conjure/client/guile/socket.fnl
@@ -41,7 +41,7 @@
   (string.gsub f ";.-\n" ""))
 
 (fn context [f] 
-  (let [stripped (strip-comments f)
+  (let [stripped (strip-comments (.. f "\n"))
         define-args (string.match stripped "%(define%-module%s+%(%s*([%g%s]-)%s*%)")]
     (if define-args 
       (normalize-context define-args) 

--- a/fnl/conjure/client/guile/socket.fnl
+++ b/fnl/conjure/client/guile/socket.fnl
@@ -47,9 +47,10 @@
 
 (fn context [f] 
   (let [stripped (strip-comments f)
-        define-args (string.match stripped "%(define%-module%s+%(%s*([%g%s]-)%s*%)")
-        context (if define-args (normalize-context define-args) nil)]
-   context))
+        define-args (string.match stripped "%(define%-module%s+%(%s*([%g%s]-)%s*%)")]
+    (if define-args 
+      (normalize-context define-args) 
+      nil)))
 
 (local form-node? ts.node-surrounded-by-form-pair-chars?)
 

--- a/fnl/conjure/client/guile/socket.fnl
+++ b/fnl/conjure/client/guile/socket.fnl
@@ -29,22 +29,19 @@
 
 (local buf-suffix ".scm")
 (local comment-prefix "; ")
-(local context-pattern "%(define%-module%s+(%([%g%s]-%))")
 
 (fn strip-comments [f]
   (string.gsub f ";.-\n" ""))
 
 (fn normalize-context [arg] 
-  (let [trimmed (str.trim arg)
-        tokens  (str.split trimmed "%s+") 
+  (let [tokens  (str.split arg "%s+") 
         context (.. "(" (str.join " " tokens) ")")]
     context))
 
 (fn context [f] 
   (let [stripped (strip-comments f)
-        define-args (string.match stripped "%(define%-module%s+%(([%g%s]-)%)")
+        define-args (string.match stripped "%(define%-module%s+%(%s*([%g%s]-)%s*%)")
         context (if define-args (normalize-context define-args) nil)]
-                              (log.append ["context" context])
    context))
 
 
@@ -217,7 +214,6 @@
  : comment-prefix
  : connect
  : context
-; : context-pattern
  : disconnect
  : doc-str
  : eval-file

--- a/fnl/conjure/client/guile/socket.fnl
+++ b/fnl/conjure/client/guile/socket.fnl
@@ -85,23 +85,26 @@
     (when (not (str.blank? clean))
       clean)))
 
- (fn build-switch-module-command [context]
-   (.. ",m " context))
+(fn build-switch-module-command [context]
+  (.. ",m " context))
 
- (fn init-module [repl context]
-   (log.dbg (.. "Initializing module for context " context))
-   (repl.send 
-     (.. (build-switch-module-command context) "\n,import " base-module ) 
-     (fn [_])))
+(fn init-module [repl context]
+  (log.dbg (.. "Initializing module for context " context))
+  (repl.send 
+    (.. (build-switch-module-command context) "\n,import " base-module ) 
+    (fn [_])))
+
+(fn ensure-module-initialized [repl context]
+ (if (not (. known-contexts context))
+   (do 
+     (init-module repl context)
+     (tset known-contexts context true))))
 
 (fn eval-str [opts]
   (with-repl-or-warn
     (fn [repl]
       (let [context (or opts.context default-context)]
-        (if (not (. known-contexts context))
-          (do 
-            (init-module repl context)
-            (tset known-contexts context true)))
+        (ensure-module-initialized repl context) 
         (-?> (.. (build-switch-module-command context) "\n" opts.code)
              (clean-input-code)
              (repl.send

--- a/lua/conjure-spec/client/guile/fake-socket.lua
+++ b/lua/conjure-spec/client/guile/fake-socket.lua
@@ -1,0 +1,10 @@
+-- [nfnl] fnl/conjure-spec/client/guile/fake-socket.fnl
+local fake_repl = {}
+local function set_fake_repl(repl)
+  fake_repl = repl
+  return nil
+end
+local function start()
+  return fake_repl
+end
+return {start = start, ["set-fake-repl"] = set_fake_repl}

--- a/lua/conjure-spec/client/guile/socket_spec.lua
+++ b/lua/conjure-spec/client/guile/socket_spec.lua
@@ -1,0 +1,140 @@
+-- [nfnl] fnl/conjure-spec/client/guile/socket_spec.fnl
+local _local_1_ = require("plenary.busted")
+local describe = _local_1_["describe"]
+local it = _local_1_["it"]
+local spy = _local_1_["spy"]
+local assert = require("luassert.assert")
+local guile = require("conjure.client.guile.socket")
+local config = require("conjure.config")
+local fake_socket = require("conjure-spec.client.guile.fake-socket")
+local function _2_()
+  package.loaded["conjure.remote.socket"] = fake_socket
+  local function _3_()
+    local function _4_()
+      return assert.are.equal(nil, guile.context("(print \"Hello World\")"))
+    end
+    it("returns nil for hello world", _4_)
+    local function _5_()
+      return assert.are.equal("(my-module)", guile.context("(define-module (my-module))"))
+    end
+    it("returns (my-module) for (define-module (my-module))", _5_)
+    local function _6_()
+      return assert.are.equal("(my-module)", guile.context("(define-module\n(my-module))"))
+    end
+    it("returns (my-module) for (define-module\\n(my-module))", _6_)
+    local function _7_()
+      return assert.are.equal("(my-module spaces)", guile.context("(define-module ( my-module  spaces   ))"))
+    end
+    it("returns (my-module spaces) for (define-module ( my-module  spaces   ))", _7_)
+    local function _8_()
+      return assert.are.equal(nil, guile.context(";(define-module (my-module))"))
+    end
+    it("returns nil for ;(define-module (my-module))", _8_)
+    local function _9_()
+      return assert.are.equal(nil, guile.context("(define-m;odule (my-module))"))
+    end
+    it("returns nil for (define-m;odule (my-module))", _9_)
+    local function _10_()
+      return assert.are.equal("(another-module)", guile.context(";\n(define-module ( another-module ))"))
+    end
+    it("returns (another-module) for ;\n(define-module ( another-module ))", _10_)
+    local function _11_()
+      return assert.are.equal("(a-module specification)", guile.context(";\n(define-module\n;some comments\n( a-module\n; more comments\n specification))"))
+    end
+    return it("returns (a-module specification) for ;\\n(define-module\\n;some comments\\n( a-module\\n; more comments\\n specification))", _11_)
+  end
+  describe("context extraction", _3_)
+  local function _12_()
+    config.merge({client = {guile = {socket = {pipename = "fake-pipe", ["host-port"] = nil}}}})
+    local function _13_()
+      local calls = {}
+      local spy_send
+      local function _14_(call)
+        return table.insert(calls, call)
+      end
+      spy_send = _14_
+      local fake_repl
+      local function _15_()
+      end
+      fake_repl = {send = spy_send, status = nil, destroy = _15_}
+      local expected_code = "(print \"Hello world\")"
+      fake_socket["set-fake-repl"](fake_repl)
+      guile.connect({})
+      fake_repl["status"] = "connected"
+      guile["eval-str"]({code = expected_code, context = nil})
+      guile.disconnect()
+      assert.are.equal(",m (guile-user)\n,import (guile)", calls[1])
+      return assert.are.equal((",m (guile-user)\n" .. expected_code), calls[2])
+    end
+    it("initializes (guile-user) when eval-str called on new repl in nil context", _13_)
+    local function _16_()
+      local calls = {}
+      local spy_send
+      local function _17_(call)
+        return table.insert(calls, call)
+      end
+      spy_send = _17_
+      local fake_repl
+      local function _18_()
+      end
+      fake_repl = {send = spy_send, status = nil, destroy = _18_}
+      local expected_code = "(print \"Hello second call\")"
+      fake_socket["set-fake-repl"](fake_repl)
+      guile.connect({})
+      fake_repl["status"] = "connected"
+      guile["eval-str"]({code = "(first-call)", context = nil})
+      guile["eval-str"]({code = expected_code, context = nil})
+      guile.disconnect()
+      return assert.are.equal((",m (guile-user)\n" .. expected_code), calls[3])
+    end
+    it("initializes (guile-user) once when eval-str called twice on repl in nil context", _16_)
+    local function _19_()
+      local calls = {}
+      local spy_send
+      local function _20_(call)
+        return table.insert(calls, call)
+      end
+      spy_send = _20_
+      local fake_repl
+      local function _21_()
+      end
+      fake_repl = {send = spy_send, status = nil, destroy = _21_}
+      local expected_code = "(print \"Hello second call\")"
+      fake_socket["set-fake-repl"](fake_repl)
+      guile.connect({})
+      fake_repl["status"] = "connected"
+      guile["eval-str"]({code = "(first-call)", context = nil})
+      guile.disconnect()
+      guile.connect({})
+      fake_repl["status"] = "connected"
+      guile["eval-str"]({code = expected_code, context = nil})
+      assert.are.equal(",m (guile-user)\n,import (guile)", calls[3])
+      return assert.are.equal((",m (guile-user)\n" .. expected_code), calls[4])
+    end
+    it("initializes (guile-user) again when eval-str disconnect eval-str is called in nil context", _19_)
+    local function _22_()
+      local calls = {}
+      local spy_send
+      local function _23_(call)
+        return table.insert(calls, call)
+      end
+      spy_send = _23_
+      local fake_repl
+      local function _24_()
+      end
+      fake_repl = {send = spy_send, status = nil, destroy = _24_}
+      local expected_module = "a-module"
+      local expected_code = "(print \"Hello second call\")"
+      fake_socket["set-fake-repl"](fake_repl)
+      guile.connect({})
+      fake_repl["status"] = "connected"
+      guile["eval-str"]({code = "(first-call)", context = nil})
+      guile["eval-str"]({code = expected_code, context = expected_module})
+      assert.are.equal((",m " .. expected_module .. "\n,import (guile)"), calls[3])
+      return assert.are.equal((",m " .. expected_module .. "\n" .. expected_code), calls[4])
+    end
+    return it("initializes (a-module) when eval-str in (guile-user) then eval-str in (a-module)", _22_)
+  end
+  return describe("module initialization", _12_)
+end
+return describe("conjure.client.guile.socket", _2_)

--- a/lua/conjure/client/guile/socket.lua
+++ b/lua/conjure/client/guile/socket.lua
@@ -23,26 +23,23 @@ end
 state = client["new-state"](_3_)
 local buf_suffix = ".scm"
 local comment_prefix = "; "
-local context_pattern = "%(define%-module%s+(%([%g%s]-%))"
 local function strip_comments(f)
   return string.gsub(f, ";.-\n", "")
 end
 local function normalize_context(arg)
-  local trimmed = str.trim(arg)
-  local tokens = str.split(trimmed, "%s+")
+  local tokens = str.split(arg, "%s+")
   local context = ("(" .. str.join(" ", tokens) .. ")")
   return context
 end
 local function context(f)
   local stripped = strip_comments(f)
-  local define_args = string.match(stripped, "%(define%-module%s+%(([%g%s]-)%)")
+  local define_args = string.match(stripped, "%(define%-module%s+%(%s*([%g%s]-)%s*%)")
   local context0
   if define_args then
     context0 = normalize_context(define_args)
   else
     context0 = nil
   end
-  log.append({"context", context0})
   return context0
 end
 local form_node_3f = ts["node-surrounded-by-form-pair-chars?"]

--- a/lua/conjure/client/guile/socket.lua
+++ b/lua/conjure/client/guile/socket.lua
@@ -83,23 +83,24 @@ local function clean_input_code(code)
     return nil
   end
 end
-local function build_switch_module_command(opts)
-  return (",m " .. (opts.context or default_context))
+local function build_switch_module_command(context0)
+  return (",m " .. context0)
 end
-local function init_module(repl, opts)
-  log.dbg(("Initializing module for context " .. opts.context))
+local function init_module(repl, context0)
+  log.dbg(("Initializing module for context " .. context0))
   local function _9_(_)
   end
-  return repl.send((build_switch_module_command(opts) .. "\n,import " .. base_module), _9_)
+  return repl.send((build_switch_module_command(context0) .. "\n,import " .. base_module), _9_)
 end
 local function eval_str(opts)
   local function _10_(repl)
-    if not known_contexts[opts.context] then
-      init_module(repl, opts)
-      known_contexts[opts.context] = true
+    local context0 = (opts.context or default_context)
+    if not known_contexts[context0] then
+      init_module(repl, context0)
+      known_contexts[context0] = true
     else
     end
-    local tmp_3_ = (",m " .. (opts.context or default_context) .. "\n" .. opts.code)
+    local tmp_3_ = (build_switch_module_command(context0) .. "\n" .. opts.code)
     if (nil ~= tmp_3_) then
       local tmp_3_0 = clean_input_code(tmp_3_)
       if (nil ~= tmp_3_0) then

--- a/lua/conjure/client/guile/socket.lua
+++ b/lua/conjure/client/guile/socket.lua
@@ -34,7 +34,7 @@ local function strip_comments(f)
   return string.gsub(f, ";.-\n", "")
 end
 local function context(f)
-  local stripped = strip_comments(f)
+  local stripped = strip_comments((f .. "\n"))
   local define_args = string.match(stripped, "%(define%-module%s+%(%s*([%g%s]-)%s*%)")
   if define_args then
     return normalize_context(define_args)

--- a/lua/conjure/client/guile/socket.lua
+++ b/lua/conjure/client/guile/socket.lua
@@ -92,14 +92,19 @@ local function init_module(repl, context0)
   end
   return repl.send((build_switch_module_command(context0) .. "\n,import " .. base_module), _9_)
 end
+local function ensure_module_initialized(repl, context0)
+  if not known_contexts[context0] then
+    init_module(repl, context0)
+    known_contexts[context0] = true
+    return nil
+  else
+    return nil
+  end
+end
 local function eval_str(opts)
-  local function _10_(repl)
+  local function _11_(repl)
     local context0 = (opts.context or default_context)
-    if not known_contexts[context0] then
-      init_module(repl, context0)
-      known_contexts[context0] = true
-    else
-    end
+    ensure_module_initialized(repl, context0)
     local tmp_3_ = (build_switch_module_command(context0) .. "\n" .. opts.code)
     if (nil ~= tmp_3_) then
       local tmp_3_0 = clean_input_code(tmp_3_)
@@ -123,7 +128,7 @@ local function eval_str(opts)
       return nil
     end
   end
-  return with_repl_or_warn(_10_)
+  return with_repl_or_warn(_11_)
 end
 local function eval_file(opts)
   return eval_str(a.assoc(opts, "code", ("(load \"" .. opts["file-path"] .. "\")")))

--- a/lua/conjure/client/guile/socket.lua
+++ b/lua/conjure/client/guile/socket.lua
@@ -24,6 +24,27 @@ state = client["new-state"](_3_)
 local buf_suffix = ".scm"
 local comment_prefix = "; "
 local context_pattern = "%(define%-module%s+(%([%g%s]-%))"
+local function strip_comments(f)
+  return string.gsub(f, ";.-\n", "")
+end
+local function normalize_context(arg)
+  local trimmed = str.trim(arg)
+  local tokens = str.split(trimmed, "%s+")
+  local context = ("(" .. str.join(" ", tokens) .. ")")
+  return context
+end
+local function context(f)
+  local stripped = strip_comments(f)
+  local define_args = string.match(stripped, "%(define%-module%s+%(([%g%s]-)%)")
+  local context0
+  if define_args then
+    context0 = normalize_context(define_args)
+  else
+    context0 = nil
+  end
+  log.append({"context", context0})
+  return context0
+end
 local form_node_3f = ts["node-surrounded-by-form-pair-chars?"]
 local function with_repl_or_warn(f, opts)
   local repl = state("repl")
@@ -43,10 +64,10 @@ local function format_message(msg)
   end
 end
 local function display_result(msg)
-  local function _6_(_241)
+  local function _7_(_241)
     return ("" ~= _241)
   end
-  return log.append(a.filter(_6_, format_message(msg)))
+  return log.append(a.filter(_7_, format_message(msg)))
 end
 local function clean_input_code(code)
   local clean = str.trim(code)
@@ -57,12 +78,12 @@ local function clean_input_code(code)
   end
 end
 local function eval_str(opts)
-  local function _8_(repl)
+  local function _9_(repl)
     local tmp_3_ = (",m " .. (opts.context or "(guile-user)") .. "\n" .. opts.code)
     if (nil ~= tmp_3_) then
       local tmp_3_0 = clean_input_code(tmp_3_)
       if (nil ~= tmp_3_0) then
-        local function _9_(msgs)
+        local function _10_(msgs)
           if ((1 == a.count(msgs)) and ("" == a["get-in"](msgs, {1, "out"}))) then
             a["assoc-in"](msgs, {1, "out"}, (comment_prefix .. "Empty result"))
           else
@@ -73,7 +94,7 @@ local function eval_str(opts)
           end
           return a["run!"](display_result, msgs)
         end
-        return repl.send(tmp_3_0, _9_, {["batch?"] = true})
+        return repl.send(tmp_3_0, _10_, {["batch?"] = true})
       else
         return nil
       end
@@ -81,43 +102,43 @@ local function eval_str(opts)
       return nil
     end
   end
-  return with_repl_or_warn(_8_)
+  return with_repl_or_warn(_9_)
 end
 local function eval_file(opts)
   return eval_str(a.assoc(opts, "code", ("(load \"" .. opts["file-path"] .. "\")")))
 end
 local function doc_str(opts)
-  local function _14_(_241)
+  local function _15_(_241)
     return ("(procedure-documentation " .. _241 .. ")")
   end
-  return eval_str(a.update(opts, "code", _14_))
+  return eval_str(a.update(opts, "code", _15_))
 end
 local function display_repl_status()
   local repl = state("repl")
   log.dbg(a.str("client.guile.socket: repl=", repl))
   if repl then
-    local _15_
+    local _16_
     do
       local pipename = a["get-in"](repl, {"opts", "pipename"})
       local host_port = a["get-in"](repl, {"opts", "host-port"})
       if pipename then
-        _15_ = (pipename .. " ")
+        _16_ = (pipename .. " ")
       elseif host_port then
-        _15_ = (host_port .. " ")
+        _16_ = (host_port .. " ")
       else
-        _15_ = "no pipename & no host-port"
+        _16_ = "no pipename & no host-port"
       end
     end
-    local _17_
+    local _18_
     do
       local err = a.get(repl, "err")
       if err then
-        _17_ = (" " .. err)
+        _18_ = (" " .. err)
       else
-        _17_ = ""
+        _18_ = ""
       end
     end
-    return log.append({(comment_prefix .. _15_ .. "(" .. repl.status .. _17_ .. ")")}, {["break?"] = true})
+    return log.append({(comment_prefix .. _16_ .. "(" .. repl.status .. _18_ .. ")")}, {["break?"] = true})
   else
     return nil
   end
@@ -138,13 +159,13 @@ local function parse_guile_result(s)
   if prompt then
     local ind1, _, result = s:find("%$%d+ = ([^\n]+)\n")
     local stray_output
-    local _21_
+    local _22_
     if result then
-      _21_ = ind1
+      _22_ = ind1
     else
-      _21_ = prompt
+      _22_ = prompt
     end
-    stray_output = s:sub(1, (_21_ - 1))
+    stray_output = s:sub(1, (_22_ - 1))
     if (#stray_output > 0) then
       log.append(text["prefixed-lines"](text["trim-last-newline"](stray_output), "; (out) "))
     else
@@ -162,9 +183,9 @@ local function connect(opts)
   local cfg_host_port = cfg({"host-port"})
   local host_port
   if cfg_host_port then
-    local _let_25_ = vim.split(cfg_host_port, ":")
-    local host = _let_25_[1]
-    local port = _let_25_[2]
+    local _let_26_ = vim.split(cfg_host_port, ":")
+    local host = _let_26_[1]
+    local port = _let_26_[2]
     log.dbg(a.str("client.guile.socket: host=", host))
     log.dbg(a.str("client.guile.socket: port=", port))
     if (not host and not port) then
@@ -185,25 +206,25 @@ local function connect(opts)
   end
   log.dbg(a.str("client.guile.socket: pipename=", pipename))
   log.dbg(a.str("client.guile.socket: host-port=", cfg_host_port))
-  local function _29_()
+  local function _30_()
     return display_repl_status()
   end
-  local function _30_(msg, repl)
+  local function _31_(msg, repl)
     display_result(msg)
-    local function _31_()
+    local function _32_()
     end
-    return repl.send(",q\n", _31_)
+    return repl.send(",q\n", _32_)
   end
-  return a.assoc(state(), "repl", socket.start({["parse-output"] = parse_guile_result, pipename = pipename, ["host-port"] = host_port, ["on-success"] = _29_, ["on-error"] = _30_, ["on-failure"] = disconnect, ["on-close"] = disconnect, ["on-stray-output"] = display_result}))
+  return a.assoc(state(), "repl", socket.start({["parse-output"] = parse_guile_result, pipename = pipename, ["host-port"] = host_port, ["on-success"] = _30_, ["on-error"] = _31_, ["on-failure"] = disconnect, ["on-close"] = disconnect, ["on-stray-output"] = display_result}))
 end
 local function on_exit()
   return disconnect()
 end
 local function on_filetype()
-  local function _32_()
+  local function _33_()
     return connect()
   end
-  mapping.buf("GuileConnect", cfg({"mapping", "connect"}), _32_, {desc = "Connect to a REPL"})
+  mapping.buf("GuileConnect", cfg({"mapping", "connect"}), _33_, {desc = "Connect to a REPL"})
   return mapping.buf("GuileDisconnect", cfg({"mapping", "disconnect"}), disconnect, {desc = "Disconnect from the REPL"})
 end
-return {["buf-suffix"] = buf_suffix, ["comment-prefix"] = comment_prefix, connect = connect, ["context-pattern"] = context_pattern, disconnect = disconnect, ["doc-str"] = doc_str, ["eval-file"] = eval_file, ["eval-str"] = eval_str, ["form-node?"] = form_node_3f, ["on-exit"] = on_exit, ["on-filetype"] = on_filetype}
+return {["buf-suffix"] = buf_suffix, ["comment-prefix"] = comment_prefix, connect = connect, context = context, disconnect = disconnect, ["doc-str"] = doc_str, ["eval-file"] = eval_file, ["eval-str"] = eval_str, ["form-node?"] = form_node_3f, ["on-exit"] = on_exit, ["on-filetype"] = on_filetype}

--- a/lua/conjure/client/guile/socket.lua
+++ b/lua/conjure/client/guile/socket.lua
@@ -43,13 +43,11 @@ end
 local function context(f)
   local stripped = strip_comments(f)
   local define_args = string.match(stripped, "%(define%-module%s+%(%s*([%g%s]-)%s*%)")
-  local context0
   if define_args then
-    context0 = normalize_context(define_args)
+    return normalize_context(define_args)
   else
-    context0 = nil
+    return nil
   end
-  return context0
 end
 local form_node_3f = ts["node-surrounded-by-form-pair-chars?"]
 local function with_repl_or_warn(f, opts)


### PR DESCRIPTION
Preface:  I'm new to this code base's conventions and established practices as well as fennel, so I'm open to any comments or changes including the overall strategy (or opinion on overall usefulness).  These are additions which I've been using in my local fork as I've been playing with Guile and feel could be helpful to others.

The current behavior of the Guile REPL is to set the module in the REPL for a given context via `,m <module name>` before any `eval-str`.  However, this module space is completely uninitialized, even missing the basic language constructs like `define`.

Consider the following example Guile module file

```
(define-module (sample-module))

(module-name (current-module))

(define x 42)
x
```

Connecting to a fresh Guile REPL and evaluating the various expressions via `<leader>er` results in `unbound variable` errors

```
; (out) GNU Guile 3.0.10
; (out) Copyright (C) 1995-2024 Free Software Foundation, Inc.
; (out) 
; (out) Guile comes with ABSOLUTELY NO WARRANTY; for details type `,show w'.
; (out) This program is free software, and you are welcome to redistribute it
; (out) under certain conditions; type `,show c' for details.
; (out) 
; (out) Enter `,help' for help.
; Empty result
; --------------------------------------------------------------------------------
; eval (root-form): (define x 42)
; ;;; socket:10:1: warning: possibly unbound variable `define'
; ;;; socket:10:8: warning: possibly unbound variable `x'
; ice-9/boot-9.scm:1676:22: In procedure raise-exception:
; Unbound variable: define
; Empty result
; --------------------------------------------------------------------------------
; eval (root-form): (module-name (current-module))
; ;;; socket:20:1: warning: possibly unbound variable `module-name'
; ;;; socket:20:14: warning: possibly unbound variable `current-module'
; ice-9/boot-9.scm:1676:22: In procedure raise-exception:
; Unbound variable: module-name
; Empty result
; --------------------------------------------------------------------------------
; eval (root-form): (define-module (sample-module))
; ;;; socket:30:1: warning: possibly unbound variable `define-module'
; ;;; socket:30:16: warning: possibly unbound variable `sample-module'
; ice-9/boot-9.scm:1676:22: In procedure raise-exception:
; Unbound variable: define-module
; Empty result
```

Examining the behavior and available modules in the REPL

```
; the default context is well-populated and usable
scheme@(guile-user)> ,import
(guile)
(system base compile)
(ice-9 session)
(ice-9 regex)
(ice-9 threads)
scheme@(guile-user)> (define x 42)
scheme@(guile-user)> x
$1 = 42
; now we switch to a context as conjure would if it sees the context (my-module)
scheme@(guile-user)> ,m (my-module)
scheme@(my-module)> ,import
; Nothing has been imported
scheme@(my-module)> (define x 43)
;;; <stdin>:6:1: warning: possibly unbound variable `define'
;;; <stdin>:6:8: warning: possibly unbound variable `x'
ice-9/boot-9.scm:1676:22: In procedure raise-exception:
Unbound variable: define

Entering a new prompt.  Type `,bt' for a backtrace or `,q' to continue.
scheme@(my-module) [1]>
```

In the default module `(guile-user)` when there is no context, we have several modules which are imported by default, including `(guile)` which provides the basic language functionality (I expect this is how many users normally interact with Guile).

As the context is conjure is read from `(define-modules (module name))`, this means there is no REPL functionality for any module file immediately after that file is opened *unless* the file itself is evaluated in its entirety.  I argue this is pretty confusing, limiting, and undesirable behavior.

A minimally-defined module will import `(guile)` by default, which provides `define`, `define-module`, etc 

```
scheme@(guile-user)> (define-module (my-module))
$1 = #<directory (my-module) 101084280>
scheme@(my-module)> ,import
(guile)
scheme@(my-module)> (define x 43)
scheme@(my-module)> x
$2 = 43
scheme@(my-module)>
```

Additionally while exploring this, I found the current context pattern is white space-sensitive and ignores comments.  E.g.

`(define-modules (    my         module       )`

results in the context `(    my         module       )` instead of `(my module)` (this however does not cause issues at the moment, but could for the content of this PR).

The current context pattern does not respect comments, so `;(define-modules (my module))` still results in the context being erroneously set to `(my module)`.

This pull request contains

- Internally keep a set of the evaluated contexts in `state`.  If a context has not been seen before when `eval-str` is called, we call `,import (guile)` prior to code evaluation 
- Clear the known contexts on disconnect
- Introduce a `context` function replacing the prior `context-pattern` to parse the context from `define-module` in a consistent way.  It is now sensitive to comments and insensitive to white space
- Establish automated tests around the evaluation and context parsing behavior
- Fix a small typo in the context documentation

I considered an alternative approach to query the REPL via `,import` to see if `(guile)` already exists, except the output for this from the REPL does not match the result parser's expected pattern (you can see this above in the given REPL sessions).  The amount of work to implement the parser change looked like a heavy lift to me (and to a lesser degree adds some back-and-forth socket traffic overhead on every `str-eval` which makes me wary of race conditions).

The REPL seems pretty robust against re-importing and re-defining things in a way such that I'm unaware of any unwanted side effects from prematurely importing `(guile)` and adding to the module's space before defining it.  `define`d variables persist in the module after `(define-module)` which has provided a natural and intuitive REPL workflow as things are incrementally changed or added.

```
scheme@(guile-user)> ,m (my-module)
scheme@(my-module)> ,import
scheme@(my-module)> ,import (guile)
scheme@(my-module)> ,import
(guile)
scheme@(my-module)> (define x 43)
scheme@(my-module)> x
$1 = 43
scheme@(my-module)> (define-module (my-module))
$2 = #<directory (my-module) 105e02f00>
scheme@(my-module)> x
$3 = 43
; x persists after calling (define-module)
scheme@(my-module)> ,m (my-module)
scheme@(my-module)> ,import
(guile)
(value-history)
scheme@(my-module)> x
$4 = 43
; nothing has changed after switching modules via ,m
```