### PR TITLE
Use Guile REPL's ,d over procedure-documentation for more robust documentation

### DIFF
--- a/fnl/conjure/client/guile/socket.fnl
+++ b/fnl/conjure/client/guile/socket.fnl
@@ -120,7 +120,7 @@
   (M.eval-str (a.assoc opts :code (.. "(load \"" opts.file-path "\")"))))
 
 (fn M.doc-str [opts]
-  (M.eval-str (a.update opts :code #(.. "(procedure-documentation " $1 ")"))))
+  (M.eval-str (a.update opts :code #(.. ",d " $1))))
 
 (fn display-repl-status []
   (let [repl (state :repl)]

--- a/lua/conjure/client/guile/socket.lua
+++ b/lua/conjure/client/guile/socket.lua
@@ -127,7 +127,7 @@ M["eval-file"] = function(opts)
 end
 M["doc-str"] = function(opts)
   local function _17_(_241)
-    return ("(procedure-documentation " .. _241 .. ")")
+    return (",d " .. _241)
   end
   return M["eval-str"](a.update(opts, "code", _17_))
 end


### PR DESCRIPTION
Using the REPL's provided `,d` ([`,describe`](https://www.gnu.org/software/guile/manual/html_node/Help-Commands.html) ) is more robust at providing documentation strings.  `,d` will provide the same functionality as `procedure-documentation` but also provide extended online documentation demonstrated below.

The output by `,d` is caught by stray output which I find reads a little bit more naturally and is better formatted for multi-line doc strings.  The current implementation writes literal `\n` for new lines and everything ends up on one line. 

```
scheme@(guile-user)> (define (some-function) "This is a function" 42)
scheme@(guile-user)> (use-modules (ice-9 regex))
scheme@(guile-user)> (procedure-documentation some-function)
$1 = "This is a function"
scheme@(guile-user)> (procedure-documentation make-regexp)
$2 = #f
scheme@(guile-user)> ,d some-function
This is a function
scheme@(guile-user)> ,d make-regexp
- Scheme Procedure: make-regexp pat .  flags
     Compile the regular expression described by PAT, and return the
     compiled regexp structure.  If PAT does not describe a legal
     regular expression, `make-regexp' throws a
     `regular-expression-syntax' error.

     The FLAGS arguments change the behavior of the compiled regular
     expression.  The following flags may be supplied:

     regexp/icase
          Consider uppercase and lowercase letters to be the same when
          matching.

     regexp/newline
          If a newline appears in the target string, then permit the `^'
          and `$' operators to match immediately after or immediately
          before the newline, respectively.  Also, the `.' and `[^...]'
          operators will never match a newline character.  The intent of
          this flag is to treat the target string as a buffer containing
          many lines of text, and the regular expression as a pattern
          that may match a single one of those lines.

     regexp/basic
          Compile a basic (``obsolete'') regexp instead of the extended
          (``modern'') regexps that are the default.  Basic regexps do
          not consider `|', `+' or `?' to be special characters, and
          require the `{...}' and `(...)' metacharacters to be
          backslash-escaped (see Backslash Escapes).  There are several
          other differences between basic and extended regular
          expressions, but these are the most significant.

     regexp/extended
          Compile an extended regular expression rather than a basic
          regexp.  This is the default behavior; this flag will not
          usually be needed.  If a call to `make-regexp' includes both
          `regexp/basic' and `regexp/extended' flags, the one which
          comes last will override the earlier one.
```