### PR TITLE
Better debug msgs for Python client and use nfnl hot reload for remote.stdio module

### DIFF
--- a/fnl/conjure/client/python/stdio.fnl
+++ b/fnl/conjure/client/python/stdio.fnl
@@ -38,8 +38,9 @@
 ; This should make it more intuitive to use <localLeader>ee to evaluate the
 ; "current form" and not be surprised that it wasn't what you thought.
 (fn M.form-node? [node]
-  (log.dbg "form-node?: node:type =" (node:type))
-  (log.dbg "form-node?: node:parent =" (node:parent))
+  ;; These debug messages will appear in the log buffer before the eval messages.
+  (log.dbg (.. "M.form-node?: node:type = " (a.pr-str (node:type))))
+  (log.dbg (.. "M.form-node?: node:parent = " (a.pr-str (node:parent))))
   (let [parent (node:parent)]
     (if (= "expression_statement" (node:type)) true
         (= "import_statement" (node:type)) true
@@ -137,6 +138,7 @@
   (= (string.sub s 1 3) "..."))
 
 (fn M.format-msg [msg]
+  (log.dbg (.. "M.format-msg: >> " msg "<<"))
   (->> (text.split-lines msg)
        (a.filter #(~= "" $1))
        (a.filter #(not (is-dots? $1)))))
@@ -167,6 +169,7 @@
       (log.append [cmd-result]))))
 
 (fn M.eval-str [opts]
+  (log.dbg (.. "M.eval-str opts >> " (a.pr-str opts) "<<"))
   (with-repl-or-warn
     (fn [repl]
       (repl.send

--- a/lua/conjure/client/python/stdio.lua
+++ b/lua/conjure/client/python/stdio.lua
@@ -27,8 +27,8 @@ state = client["new-state"](_3_)
 M["buf-suffix"] = ".py"
 M["comment-prefix"] = "# "
 M["form-node?"] = function(node)
-  log.dbg("form-node?: node:type =", node:type())
-  log.dbg("form-node?: node:parent =", node:parent())
+  log.dbg(("M.form-node?: node:type = " .. a["pr-str"](node:type())))
+  log.dbg(("M.form-node?: node:parent = " .. a["pr-str"](node:parent())))
   local parent = node:parent()
   if ("expression_statement" == node:type()) then
     return true
@@ -93,6 +93,7 @@ local function is_dots_3f(s)
   return (string.sub(s, 1, 3) == "...")
 end
 M["format-msg"] = function(msg)
+  log.dbg(("M.format-msg: >> " .. msg .. "<<"))
   local function _9_(_241)
     return not is_dots_3f(_241)
   end
@@ -136,6 +137,7 @@ local function log_repl_output(msgs)
   end
 end
 M["eval-str"] = function(opts)
+  log.dbg(("M.eval-str opts >> " .. a["pr-str"](opts) .. "<<"))
   local function _16_(repl)
     local function _17_(msgs)
       log_repl_output(msgs)

--- a/lua/conjure/remote/stdio.lua
+++ b/lua/conjure/remote/stdio.lua
@@ -1,11 +1,13 @@
 -- [nfnl] fnl/conjure/remote/stdio.fnl
 local _local_1_ = require("conjure.nfnl.module")
 local autoload = _local_1_["autoload"]
+local define = _local_1_["define"]
 local a = autoload("conjure.aniseed.core")
 local str = autoload("conjure.aniseed.string")
 local client = autoload("conjure.client")
 local log = autoload("conjure.log")
-local uv = vim.loop
+local M = define("conjure.remote.stdio")
+local uv = vim.uv
 local function parse_prompt(s, pat)
   if s:find(pat) then
     return true, s:gsub(pat, "")
@@ -13,11 +15,11 @@ local function parse_prompt(s, pat)
     return false, s
   end
 end
-local function parse_cmd(x)
+M["parse-cmd"] = function(x)
   if a["table?"](x) then
     return {cmd = a.first(x), args = a.rest(x)}
   elseif a["string?"](x) then
-    return parse_cmd(str.split(x, "%s"))
+    return M["parse-cmd"](str.split(x, "%s"))
   else
     return nil
   end
@@ -30,7 +32,7 @@ local function extend_env(vars)
   end
   return a.map(_5_, a["kv-pairs"](a.merge(vim.fn.environ(), vars)))
 end
-local function start(opts)
+M.start = function(opts)
   local stdin = uv.new_pipe(false)
   local stdout = uv.new_pipe(false)
   local stderr = uv.new_pipe(false)
@@ -78,14 +80,16 @@ local function start(opts)
     if (next_msg and not repl.current) then
       table.remove(repl.queue, 1)
       a.assoc(repl, "current", next_msg)
-      log.dbg("send", next_msg.code)
+      log.dbg(("remote.stdio.next-in-queue; stdin:write next-msg.code >>" .. a["pr-str"](next_msg.code) .. "<<"))
       return stdin:write(next_msg.code)
     else
       return nil
     end
   end
   local function on_message(source, err, chunk)
-    log.dbg("receive", source, err, chunk)
+    log.dbg(("remote.stdio.on-message; receive source >>" .. source .. "<<"))
+    log.dbg(("remote.stdio.on-message; receive err >>" .. a["pr-str"](err) .. "<<"))
+    log.dbg(("remote.stdio.on-message; receive chunk >>" .. a["pr-str"](chunk) .. "<<"))
     if err then
       opts["on-error"](err)
       return destroy()
@@ -148,7 +152,7 @@ local function start(opts)
     uv.process_kill(repl.handle, signal)
     return nil
   end
-  local _let_27_ = parse_cmd(opts.cmd)
+  local _let_27_ = M["parse-cmd"](opts.cmd)
   local cmd = _let_27_["cmd"]
   local args = _let_27_["args"]
   local handle, pid_or_err = uv.spawn(cmd, {stdio = {stdin, stdout, stderr}, args = args, env = extend_env(a["merge!"]({INPUTRC = "/dev/null", TERM = "dumb"}, opts.env))}, client["schedule-wrap"](on_exit))
@@ -168,4 +172,4 @@ local function start(opts)
     return destroy()
   end
 end
-return {["parse-cmd"] = parse_cmd, start = start}
+return M


### PR DESCRIPTION
While trying to see how `nfnl`'s module hot reloading works, I:
- Changed the debug messages a bit for the Python client and the `remote.stdio` module that stdio-based clients use.
- Changed the `remote.stdio` module to use the nfnl hot reloading capability.

While editing `fnl/conjure/client/python/stdio.fnl`, I noticed that I needed to evalutate the file (`,ef`) before the new changes worked when editing `dev/python/sandbox.py` in another buffer.

`nfnl` hot reloading is awesome! It makes it easier to work on changes to Conjure clients. I can start one Neovim session and edit a client while using that client. Of course, in this case, I have my local Conjure repo being loaded as the Conjure plugin.