### PR TITLE
Prevalidate scheme and Guile before eval

### DIFF
--- a/fnl/conjure-spec/client/guile/socket_spec.fnl
+++ b/fnl/conjure-spec/client/guile/socket_spec.fnl
@@ -3,7 +3,11 @@
 (local guile (require :conjure.client.guile.socket))
 (local config (require :conjure.config))
 (local fake-socket (require :conjure-spec.client.guile.fake-socket))
+(local ts (require :conjure.tree-sitter))
 (require :conjure-spec.assertions)
+
+(tset package.loaded "conjure.remote.socket" fake-socket)
+(tset ts :valid-str? (fn [_ _] true))
 
 (local completion-code-define-match "%(define%* %(%%conjure:get%-guile%-completions")
 
@@ -13,7 +17,6 @@
 
 (describe "conjure.client.guile.socket"
   (fn []
-    (tset package.loaded "conjure.remote.socket" fake-socket)
     (describe "context extraction"
       (fn [] 
         (it "returns nil for hello world"

--- a/fnl/conjure/client/guile/socket.fnl
+++ b/fnl/conjure/client/guile/socket.fnl
@@ -110,7 +110,8 @@
 (fn M.eval-str [opts]
   (with-repl-or-warn
     (fn [repl]
-      (let [context (or opts.context default-context)]
+      (if (ts.valid-str? :scheme opts.code)
+       (let [context (or opts.context default-context)]
         (ensure-module-initialized repl context) 
         (-?> (.. (build-switch-module-command context) "\n" opts.code)
              (clean-input-code)
@@ -124,7 +125,8 @@
                    (opts.on-result (str.join "\n" (format-message (a.last msgs)))))
                  (when (not opts.passive?)
                    (a.run! display-result msgs)))
-               {:batch? true}))))))
+               {:batch? true})))
+       (log.append [(.. M.comment-prefix "eval error: could not parse form")])))))
 
 (fn M.eval-file [opts]
   (M.eval-str (a.assoc opts :code (.. "(load \"" opts.file-path "\")"))))

--- a/fnl/conjure/client/scheme/stdio.fnl
+++ b/fnl/conjure/client/scheme/stdio.fnl
@@ -65,13 +65,15 @@
 (fn eval-str [opts]
   (with-repl-or-warn
     (fn [repl]
-      (repl.send
+      (if (ts.valid-str? :scheme opts.code) 
+       (repl.send
         (.. opts.code "\n")
         (fn [msgs]
           (let [msgs (-> msgs unbatch format-msg)]
             (opts.on-result (a.last msgs))
             (log.append msgs)))
-        {:batch? true}))))
+        {:batch? true})
+       (log.append [(.. comment-prefix "eval error: could not parse form")])))))
 
 (fn eval-file [opts]
   (eval-str (a.assoc opts :code (.. "(load \"" opts.file-path "\")"))))

--- a/fnl/conjure/tree-sitter.fnl
+++ b/fnl/conjure/tree-sitter.fnl
@@ -200,6 +200,14 @@
        vim.treesitter.require_language)
    lang))
 
+(fn valid-str? [lang code]
+  (-?> (vim.treesitter.get_string_parser code lang)
+       (#(doto $1 (: :parse)))
+       (: :trees)
+       (a.get-in [1])
+       (: :root)
+       (#(not ($1:has_error)))))
+
 {: enabled?
  : parse!
  : node->str
@@ -215,4 +223,5 @@
  : node-surrounded-by-form-pair-chars?
  : node-prefixed-by-chars?
  : get-form
- : add-language}
+ : add-language
+ : valid-str?}

--- a/lua/conjure-spec/client/guile/socket_spec.lua
+++ b/lua/conjure-spec/client/guile/socket_spec.lua
@@ -7,58 +7,63 @@ local assert = require("luassert.assert")
 local guile = require("conjure.client.guile.socket")
 local config = require("conjure.config")
 local fake_socket = require("conjure-spec.client.guile.fake-socket")
+local ts = require("conjure.tree-sitter")
 require("conjure-spec.assertions")
+package.loaded["conjure.remote.socket"] = fake_socket
+local function _2_(_, _0)
+  return true
+end
+ts["valid-str?"] = _2_
 local completion_code_define_match = "%(define%* %(%%conjure:get%-guile%-completions"
 local function set_repl_connected(repl)
   repl["status"] = "connected"
   return nil
 end
-local function _2_()
-  package.loaded["conjure.remote.socket"] = fake_socket
-  local function _3_()
-    local function _4_()
+local function _3_()
+  local function _4_()
+    local function _5_()
       return assert.are.equal(nil, guile.context("(print \"Hello World\")"))
     end
-    it("returns nil for hello world", _4_)
-    local function _5_()
+    it("returns nil for hello world", _5_)
+    local function _6_()
       return assert.are.equal("(my-module)", guile.context("(define-module (my-module))"))
     end
-    it("returns (my-module) for (define-module (my-module))", _5_)
-    local function _6_()
+    it("returns (my-module) for (define-module (my-module))", _6_)
+    local function _7_()
       return assert.are.equal("(my-module)", guile.context("(define-module\n(my-module))"))
     end
-    it("returns (my-module) for (define-module\\n(my-module))", _6_)
-    local function _7_()
+    it("returns (my-module) for (define-module\\n(my-module))", _7_)
+    local function _8_()
       return assert.are.equal("(my-module spaces)", guile.context("(define-module ( my-module  spaces   ))"))
     end
-    it("returns (my-module spaces) for (define-module ( my-module  spaces   ))", _7_)
-    local function _8_()
+    it("returns (my-module spaces) for (define-module ( my-module  spaces   ))", _8_)
+    local function _9_()
       return assert.are.equal(nil, guile.context(";(define-module (my-module))"))
     end
-    it("returns nil for ;(define-module (my-module))", _8_)
-    local function _9_()
+    it("returns nil for ;(define-module (my-module))", _9_)
+    local function _10_()
       return assert.are.equal(nil, guile.context("(define-m;odule (my-module))"))
     end
-    it("returns nil for (define-m;odule (my-module))", _9_)
-    local function _10_()
+    it("returns nil for (define-m;odule (my-module))", _10_)
+    local function _11_()
       return assert.are.equal("(another-module)", guile.context(";\n(define-module ( another-module ))"))
     end
-    it("returns (another-module) for ;\n(define-module ( another-module ))", _10_)
-    local function _11_()
+    it("returns (another-module) for ;\n(define-module ( another-module ))", _11_)
+    local function _12_()
       return assert.are.equal("(a-module specification)", guile.context(";\n(define-module\n;some comments\n( a-module\n; more comments\n specification))"))
     end
-    return it("returns (a-module specification) for ;\\n(define-module\\n;some comments\\n( a-module\\n; more comments\\n specification))", _11_)
+    return it("returns (a-module specification) for ;\\n(define-module\\n;some comments\\n( a-module\\n; more comments\\n specification))", _12_)
   end
-  describe("context extraction", _3_)
-  local function _12_()
+  describe("context extraction", _4_)
+  local function _13_()
     config.merge({client = {guile = {socket = {pipename = "fake-pipe", host_port = nil}}}}, {["overwrite?"] = true})
-    local function _13_()
+    local function _14_()
       local calls = {}
       local spy_send
-      local function _14_(call)
+      local function _15_(call)
         return table.insert(calls, call)
       end
-      spy_send = _14_
+      spy_send = _15_
       local fake_repl = fake_socket["build-fake-repl"](spy_send)
       local expected_code = "(print \"Hello world\")"
       fake_socket["set-fake-repl"](fake_repl)
@@ -70,14 +75,14 @@ local function _2_()
       assert["has-substring"](completion_code_define_match, calls[2])
       return assert.are.equal((",m (guile-user)\n" .. expected_code), calls[3])
     end
-    it("initializes (guile-user) when eval-str called on new repl in nil context", _13_)
-    local function _15_()
+    it("initializes (guile-user) when eval-str called on new repl in nil context", _14_)
+    local function _16_()
       local calls = {}
       local spy_send
-      local function _16_(call)
+      local function _17_(call)
         return table.insert(calls, call)
       end
-      spy_send = _16_
+      spy_send = _17_
       local fake_repl = fake_socket["build-fake-repl"](spy_send)
       local expected_code = "(print \"Hello second call\")"
       fake_socket["set-fake-repl"](fake_repl)
@@ -88,14 +93,14 @@ local function _2_()
       guile.disconnect()
       return assert.are.equal((",m (guile-user)\n" .. expected_code), calls[4])
     end
-    it("initializes (guile-user) once when eval-str called twice on repl in nil context", _15_)
-    local function _17_()
+    it("initializes (guile-user) once when eval-str called twice on repl in nil context", _16_)
+    local function _18_()
       local calls = {}
       local spy_send
-      local function _18_(call)
+      local function _19_(call)
         return table.insert(calls, call)
       end
-      spy_send = _18_
+      spy_send = _19_
       local fake_repl = fake_socket["build-fake-repl"](spy_send)
       local expected_code = "(print \"Hello second call\")"
       fake_socket["set-fake-repl"](fake_repl)
@@ -111,18 +116,18 @@ local function _2_()
       assert["has-substring"](completion_code_define_match, calls[5])
       return assert.are.equal((",m (guile-user)\n" .. expected_code), calls[6])
     end
-    it("initializes (guile-user) again when eval-str disconnect eval-str is called in nil context", _17_)
-    local function _19_()
+    it("initializes (guile-user) again when eval-str disconnect eval-str is called in nil context", _18_)
+    local function _20_()
       local calls = {}
       local spy_send
-      local function _20_(call)
+      local function _21_(call)
         return table.insert(calls, call)
       end
-      spy_send = _20_
+      spy_send = _21_
       local fake_repl
-      local function _21_()
+      local function _22_()
       end
-      fake_repl = {send = spy_send, status = nil, destroy = _21_}
+      fake_repl = {send = spy_send, status = nil, destroy = _22_}
       local expected_module = "a-module"
       local expected_code = "(print \"Hello second call\")"
       fake_socket["set-fake-repl"](fake_repl)
@@ -135,49 +140,49 @@ local function _2_()
       assert["has-substring"](completion_code_define_match, calls[5])
       return assert.are.equal((",m " .. expected_module .. "\n" .. expected_code), calls[6])
     end
-    return it("initializes (a-module) when eval-str in (guile-user) then eval-str in (a-module)", _19_)
+    return it("initializes (a-module) when eval-str in (guile-user) then eval-str in (a-module)", _20_)
   end
-  describe("module initialization", _12_)
-  local function _22_()
+  describe("module initialization", _13_)
+  local function _23_()
     config.merge({client = {guile = {socket = {pipename = "fake-pipe", host_port = nil}}}}, {["overwrite?"] = true})
-    local function _23_()
+    local function _24_()
       local calls = {}
       local spy_send
-      local function _24_(call)
+      local function _25_(call)
         return table.insert(calls, call)
       end
-      spy_send = _24_
+      spy_send = _25_
       local fake_repl = fake_socket["build-fake-repl"](spy_send)
       local callback_results = {}
       local fake_callback
-      local function _25_(result)
+      local function _26_(result)
         return table.insert(callback_results, result)
       end
-      fake_callback = _25_
+      fake_callback = _26_
       fake_socket["set-fake-repl"](fake_repl)
       guile.completions({cb = fake_callback, prefix = "something"})
       assert.same({}, calls)
       return assert.same({}, callback_results[1])
     end
-    it("Does not execute completions in REPL when not connected", _23_)
-    local function _26_()
+    it("Does not execute completions in REPL when not connected", _24_)
+    local function _27_()
       local calls = {}
       local spy_send
-      local function _27_(call, callback)
+      local function _28_(call, callback)
         return table.insert(calls, {code = call, callback = callback})
       end
-      spy_send = _27_
+      spy_send = _28_
       local fake_repl
-      local function _28_()
+      local function _29_()
       end
-      fake_repl = {send = spy_send, status = nil, destroy = _28_}
+      fake_repl = {send = spy_send, status = nil, destroy = _29_}
       local expected_code = "%(%%conjure:get%-guile%-completions \"d\"%)"
       local callback_results = {}
       local fake_callback
-      local function _29_(result)
+      local function _30_(result)
         return table.insert(callback_results, result)
       end
-      fake_callback = _29_
+      fake_callback = _30_
       fake_socket["set-fake-repl"](fake_repl)
       guile.connect({})
       set_repl_connected(fake_repl)
@@ -188,21 +193,21 @@ local function _2_()
       assert["has-substring"](expected_code, completion_call.code)
       return assert.same({"define"}, callback_results[1])
     end
-    it("Executes completions in REPL for prefix d with result define", _26_)
-    local function _30_()
+    it("Executes completions in REPL for prefix d with result define", _27_)
+    local function _31_()
       local sent_callbacks = {}
       local spy_send
-      local function _31_(_, callback)
+      local function _32_(_, callback)
         return table.insert(sent_callbacks, callback)
       end
-      spy_send = _31_
+      spy_send = _32_
       local fake_repl = fake_socket["build-fake-repl"](spy_send)
       local callback_results = {}
       local fake_callback
-      local function _32_(result)
+      local function _33_(result)
         return table.insert(callback_results, result)
       end
-      fake_callback = _32_
+      fake_callback = _33_
       fake_socket["set-fake-repl"](fake_repl)
       guile.connect({})
       set_repl_connected(fake_repl)
@@ -211,22 +216,22 @@ local function _2_()
       guile.disconnect()
       return assert.same({"future", "fun", "func"}, callback_results[1])
     end
-    return it("Puts last completion first for prefix fu with results fun func and future", _30_)
+    return it("Puts last completion first for prefix fu with results fun func and future", _31_)
   end
-  describe("completions", _22_)
-  local function _33_()
-    local function _34_()
+  describe("completions", _23_)
+  local function _34_()
+    local function _35_()
       config.merge({client = {guile = {socket = {pipename = "fake-pipe", host_port = nil, enable_completions = false}}}}, {["overwrite?"] = true})
       local calls = {}
       local spy_send
-      local function _35_(call)
+      local function _36_(call)
         return table.insert(calls, call)
       end
-      spy_send = _35_
+      spy_send = _36_
       local fake_repl
-      local function _36_()
+      local function _37_()
       end
-      fake_repl = {send = spy_send, status = nil, destroy = _36_}
+      fake_repl = {send = spy_send, status = nil, destroy = _37_}
       local expected_code = "(print \"Hello world\")"
       fake_socket["set-fake-repl"](fake_repl)
       guile.connect({})
@@ -236,15 +241,15 @@ local function _2_()
       assert.are.equal(",m (guile-user)\n,import (guile)", calls[1])
       return assert.are.equal((",m (guile-user)\n" .. expected_code), calls[2])
     end
-    it("Does not load completion code when completions disabled in config", _34_)
-    local function _37_()
+    it("Does not load completion code when completions disabled in config", _35_)
+    local function _38_()
       config.merge({client = {guile = {socket = {pipename = "fake-pipe", host_port = nil, enable_completions = true}}}}, {["overwrite?"] = true})
       local calls = {}
       local spy_send
-      local function _38_(call)
+      local function _39_(call)
         return table.insert(calls, call)
       end
-      spy_send = _38_
+      spy_send = _39_
       local fake_repl = fake_socket["build-fake-repl"](spy_send)
       local expected_code = "(print \"Hello world\")"
       fake_socket["set-fake-repl"](fake_repl)
@@ -256,25 +261,25 @@ local function _2_()
       assert["has-substring"](completion_code_define_match, calls[2])
       return assert.are.equal((",m (guile-user)\n" .. expected_code), calls[3])
     end
-    it("Does load completion code when completions enabled in config", _37_)
-    local function _39_()
+    it("Does load completion code when completions enabled in config", _38_)
+    local function _40_()
       config.merge({client = {guile = {socket = {pipename = "fake-pipe", host_port = nil, enable_completions = false}}}}, {["overwrite?"] = true})
       local calls = {}
       local spy_send
-      local function _40_(call)
+      local function _41_(call)
         return table.insert(calls, call)
       end
-      spy_send = _40_
+      spy_send = _41_
       local fake_repl
-      local function _41_()
+      local function _42_()
       end
-      fake_repl = {send = spy_send, status = nil, destroy = _41_}
+      fake_repl = {send = spy_send, status = nil, destroy = _42_}
       local callback_results = {}
       local fake_callback
-      local function _42_(result)
+      local function _43_(result)
         return table.insert(callback_results, result)
       end
-      fake_callback = _42_
+      fake_callback = _43_
       fake_socket["set-fake-repl"](fake_repl)
       guile.connect({})
       set_repl_connected(fake_repl)
@@ -283,8 +288,8 @@ local function _2_()
       assert.same({}, calls)
       return assert.same({}, callback_results[1])
     end
-    return it("Does not execute completions in REPL when connected but completions disabled", _39_)
+    return it("Does not execute completions in REPL when connected but completions disabled", _40_)
   end
-  return describe("enable completions config setting", _33_)
+  return describe("enable completions config setting", _34_)
 end
-return describe("conjure.client.guile.socket", _2_)
+return describe("conjure.client.guile.socket", _3_)

--- a/lua/conjure/client/guile/socket.lua
+++ b/lua/conjure/client/guile/socket.lua
@@ -106,33 +106,37 @@ local function ensure_module_initialized(repl, context)
 end
 M["eval-str"] = function(opts)
   local function _13_(repl)
-    local context = (opts.context or default_context)
-    ensure_module_initialized(repl, context)
-    local tmp_3_ = (build_switch_module_command(context) .. "\n" .. opts.code)
-    if (nil ~= tmp_3_) then
-      local tmp_3_0 = clean_input_code(tmp_3_)
-      if (nil ~= tmp_3_0) then
-        local function _14_(msgs)
-          if ((1 == a.count(msgs)) and ("" == a["get-in"](msgs, {1, "out"}))) then
-            a["assoc-in"](msgs, {1, "out"}, (M["comment-prefix"] .. "Empty result"))
-          else
+    if ts["valid-str?"]("scheme", opts.code) then
+      local context = (opts.context or default_context)
+      ensure_module_initialized(repl, context)
+      local tmp_3_ = (build_switch_module_command(context) .. "\n" .. opts.code)
+      if (nil ~= tmp_3_) then
+        local tmp_3_0 = clean_input_code(tmp_3_)
+        if (nil ~= tmp_3_0) then
+          local function _14_(msgs)
+            if ((1 == a.count(msgs)) and ("" == a["get-in"](msgs, {1, "out"}))) then
+              a["assoc-in"](msgs, {1, "out"}, (M["comment-prefix"] .. "Empty result"))
+            else
+            end
+            if opts["on-result"] then
+              opts["on-result"](str.join("\n", format_message(a.last(msgs))))
+            else
+            end
+            if not opts["passive?"] then
+              return a["run!"](display_result, msgs)
+            else
+              return nil
+            end
           end
-          if opts["on-result"] then
-            opts["on-result"](str.join("\n", format_message(a.last(msgs))))
-          else
-          end
-          if not opts["passive?"] then
-            return a["run!"](display_result, msgs)
-          else
-            return nil
-          end
+          return repl.send(tmp_3_0, _14_, {["batch?"] = true})
+        else
+          return nil
         end
-        return repl.send(tmp_3_0, _14_, {["batch?"] = true})
       else
         return nil
       end
     else
-      return nil
+      return log.append({(M["comment-prefix"] .. "eval error: could not parse form")})
     end
   end
   return with_repl_or_warn(_13_)
@@ -141,37 +145,37 @@ M["eval-file"] = function(opts)
   return M["eval-str"](a.assoc(opts, "code", ("(load \"" .. opts["file-path"] .. "\")")))
 end
 M["doc-str"] = function(opts)
-  local function _20_(_241)
+  local function _21_(_241)
     return (",d " .. _241)
   end
-  return M["eval-str"](a.update(opts, "code", _20_))
+  return M["eval-str"](a.update(opts, "code", _21_))
 end
 local function display_repl_status()
   local repl = state("repl")
   log.dbg(a.str("client.guile.socket: repl=", repl))
   if repl then
-    local _21_
+    local _22_
     do
       local pipename = a["get-in"](repl, {"opts", "pipename"})
       local host_port = a["get-in"](repl, {"opts", "host_port"})
       if pipename then
-        _21_ = (pipename .. " ")
+        _22_ = (pipename .. " ")
       elseif host_port then
-        _21_ = (host_port .. " ")
+        _22_ = (host_port .. " ")
       else
-        _21_ = "no pipename & no host-port"
+        _22_ = "no pipename & no host-port"
       end
     end
-    local _23_
+    local _24_
     do
       local err = a.get(repl, "err")
       if err then
-        _23_ = (" " .. err)
+        _24_ = (" " .. err)
       else
-        _23_ = ""
+        _24_ = ""
       end
     end
-    return log.append({(M["comment-prefix"] .. _21_ .. "(" .. repl.status .. _23_ .. ")")}, {["break?"] = true})
+    return log.append({(M["comment-prefix"] .. _22_ .. "(" .. repl.status .. _24_ .. ")")}, {["break?"] = true})
   else
     return nil
   end
@@ -194,13 +198,13 @@ local function parse_guile_result(s)
   if prompt then
     local ind1, _, result = s:find("%$%d+ = ([^\n]+)\n")
     local stray_output
-    local _27_
+    local _28_
     if result then
-      _27_ = ind1
+      _28_ = ind1
     else
-      _27_ = prompt
+      _28_ = prompt
     end
-    stray_output = s:sub(1, (_27_ - 1))
+    stray_output = s:sub(1, (_28_ - 1))
     if (#stray_output > 0) then
       log.append(text["prefixed-lines"](text["trim-last-newline"](stray_output), "; (out) "))
     else
@@ -218,9 +222,9 @@ M.connect = function(_opts)
   local cfg_host_port = cfg({"host_port"})
   local host_port
   if cfg_host_port then
-    local _let_31_ = vim.split(cfg_host_port, ":")
-    local host = _let_31_[1]
-    local port = _let_31_[2]
+    local _let_32_ = vim.split(cfg_host_port, ":")
+    local host = _let_32_[1]
+    local port = _let_32_[2]
     log.dbg(a.str("client.guile.socket: host=", host))
     log.dbg(a.str("client.guile.socket: port=", port))
     if (not host and not port) then
@@ -241,16 +245,16 @@ M.connect = function(_opts)
   end
   log.dbg(a.str("client.guile.socket: pipename=", pipename))
   log.dbg(a.str("client.guile.socket: host-port=", cfg_host_port))
-  local function _35_()
+  local function _36_()
     return display_repl_status()
   end
-  local function _36_(msg, repl)
+  local function _37_(msg, repl)
     display_result(msg)
-    local function _37_()
+    local function _38_()
     end
-    return repl.send(",q\n", _37_)
+    return repl.send(",q\n", _38_)
   end
-  return a.assoc(state(), "repl", socket.start({["parse-output"] = parse_guile_result, pipename = pipename, ["host-port"] = host_port, ["on-success"] = _35_, ["on-error"] = _36_, ["on-failure"] = M.disconnect, ["on-close"] = M.disconnect, ["on-stray-output"] = display_result}))
+  return a.assoc(state(), "repl", socket.start({["parse-output"] = parse_guile_result, pipename = pipename, ["host-port"] = host_port, ["on-success"] = _36_, ["on-error"] = _37_, ["on-failure"] = M.disconnect, ["on-close"] = M.disconnect, ["on-stray-output"] = display_result}))
 end
 local function connected_3f()
   if state("repl") then
@@ -263,24 +267,24 @@ M["on-exit"] = function()
   return M.disconnect()
 end
 M["on-filetype"] = function()
-  local function _39_()
+  local function _40_()
     return M.connect()
   end
-  mapping.buf("GuileConnect", cfg({"mapping", "connect"}), _39_, {desc = "Connect to a REPL"})
-  local function _40_()
+  mapping.buf("GuileConnect", cfg({"mapping", "connect"}), _40_, {desc = "Connect to a REPL"})
+  local function _41_()
     return M.disconnect()
   end
-  return mapping.buf("GuileDisconnect", cfg({"mapping", "disconnect"}), _40_, {desc = "Disconnect from the REPL"})
+  return mapping.buf("GuileDisconnect", cfg({"mapping", "disconnect"}), _41_, {desc = "Disconnect from the REPL"})
 end
 M.completions = function(opts)
   if (completions_enabled_3f() and connected_3f()) then
     local code = cmpl["build-completion-request"](opts.prefix)
     local result_fn
-    local function _41_(results)
+    local function _42_(results)
       local cmpl_list = cmpl["format-results"](results)
       return opts.cb(cmpl_list)
     end
-    result_fn = _41_
+    result_fn = _42_
     a.assoc(opts, "code", code)
     a.assoc(opts, "on-result", result_fn)
     a.assoc(opts, "passive?", true)

--- a/lua/conjure/client/scheme/stdio.lua
+++ b/lua/conjure/client/scheme/stdio.lua
@@ -55,12 +55,16 @@ local function format_msg(msg)
 end
 local function eval_str(opts)
   local function _9_(repl)
-    local function _10_(msgs)
-      local msgs0 = format_msg(unbatch(msgs))
-      opts["on-result"](a.last(msgs0))
-      return log.append(msgs0)
+    if ts["valid-str?"]("scheme", opts.code) then
+      local function _10_(msgs)
+        local msgs0 = format_msg(unbatch(msgs))
+        opts["on-result"](a.last(msgs0))
+        return log.append(msgs0)
+      end
+      return repl.send((opts.code .. "\n"), _10_, {["batch?"] = true})
+    else
+      return log.append({(comment_prefix .. "eval error: could not parse form")})
     end
-    return repl.send((opts.code .. "\n"), _10_, {["batch?"] = true})
   end
   return with_repl_or_warn(_9_)
 end
@@ -84,13 +88,13 @@ local function start()
   if state("repl") then
     return log.append({(comment_prefix .. "Can't start, REPL is already running."), (comment_prefix .. "Stop the REPL with " .. config["get-in"]({"mapping", "prefix"}) .. cfg({"mapping", "stop"}))}, {["break?"] = true})
   else
-    local function _12_()
+    local function _13_()
       return display_repl_status("started")
     end
-    local function _13_(err)
+    local function _14_(err)
       return display_repl_status(err)
     end
-    local function _14_(code, signal)
+    local function _15_(code, signal)
       if (("number" == type(code)) and (code > 0)) then
         log.append({(comment_prefix .. "process exited with code " .. code)})
       else
@@ -101,18 +105,18 @@ local function start()
       end
       return stop()
     end
-    local function _17_(msg)
+    local function _18_(msg)
       return log.append(format_msg(msg))
     end
-    return a.assoc(state(), "repl", stdio.start({["prompt-pattern"] = cfg({"prompt_pattern"}), cmd = cfg({"command"}), ["on-success"] = _12_, ["on-error"] = _13_, ["on-exit"] = _14_, ["on-stray-output"] = _17_}))
+    return a.assoc(state(), "repl", stdio.start({["prompt-pattern"] = cfg({"prompt_pattern"}), cmd = cfg({"command"}), ["on-success"] = _13_, ["on-error"] = _14_, ["on-exit"] = _15_, ["on-stray-output"] = _18_}))
   end
 end
 local function interrupt()
-  local function _19_(repl)
+  local function _20_(repl)
     log.append({(comment_prefix .. " Sending interrupt signal.")}, {["break?"] = true})
     return repl["send-signal"]("sigint")
   end
-  return with_repl_or_warn(_19_)
+  return with_repl_or_warn(_20_)
 end
 local function on_load()
   return start()

--- a/lua/conjure/tree-sitter.lua
+++ b/lua/conjure/tree-sitter.lua
@@ -177,4 +177,40 @@ end
 local function add_language(lang)
   return (vim.treesitter.language.add or vim.treesitter.language.require_language or vim.treesitter.require_language)(lang)
 end
-return {["enabled?"] = enabled_3f, ["parse!"] = parse_21, ["node->str"] = node__3estr, ["lisp-comment-node?"] = lisp_comment_node_3f, parent = parent, ["document?"] = document_3f, range = range, ["node->table"] = node__3etable, ["get-root"] = get_root, ["leaf?"] = leaf_3f, ["sym?"] = sym_3f, ["get-leaf"] = get_leaf, ["node-surrounded-by-form-pair-chars?"] = node_surrounded_by_form_pair_chars_3f, ["node-prefixed-by-chars?"] = node_prefixed_by_chars_3f, ["get-form"] = get_form, ["add-language"] = add_language}
+local function valid_str_3f(lang, code)
+  local tmp_3_ = vim.treesitter.get_string_parser(code, lang)
+  if (nil ~= tmp_3_) then
+    local tmp_3_0
+    local function _27_(_241)
+      _241:parse()
+      return _241
+    end
+    tmp_3_0 = _27_(tmp_3_)
+    if (nil ~= tmp_3_0) then
+      local tmp_3_1 = tmp_3_0:trees()
+      if (nil ~= tmp_3_1) then
+        local tmp_3_2 = a["get-in"](tmp_3_1, {1})
+        if (nil ~= tmp_3_2) then
+          local tmp_3_3 = tmp_3_2:root()
+          if (nil ~= tmp_3_3) then
+            local function _28_(_241)
+              return not _241:has_error()
+            end
+            return _28_(tmp_3_3)
+          else
+            return nil
+          end
+        else
+          return nil
+        end
+      else
+        return nil
+      end
+    else
+      return nil
+    end
+  else
+    return nil
+  end
+end
+return {["enabled?"] = enabled_3f, ["parse!"] = parse_21, ["node->str"] = node__3estr, ["lisp-comment-node?"] = lisp_comment_node_3f, parent = parent, ["document?"] = document_3f, range = range, ["node->table"] = node__3etable, ["get-root"] = get_root, ["leaf?"] = leaf_3f, ["sym?"] = sym_3f, ["get-leaf"] = get_leaf, ["node-surrounded-by-form-pair-chars?"] = node_surrounded_by_form_pair_chars_3f, ["node-prefixed-by-chars?"] = node_prefixed_by_chars_3f, ["get-form"] = get_form, ["add-language"] = add_language, ["valid-str?"] = valid_str_3f}


### PR DESCRIPTION
Incomplete expressions will leave the Guile and scheme REPLs waiting for continued input effectively breaking it until it is disconnected/reconnected.  To help preserve health of the REPL we can use tree sitter to at least make sure strings to be evaluated at least parse before evaluation.

I was unable to determine a different kind of check to see if the REPL would be responsive or if there was something we can feed it to put it in a known state, but it seems to me like there's no observable difference between waiting for more input or a long-running evaluation.

Consider the code

```
(define x 33
x
```

Evaluating this either as a buffer or as a root form will silently hang the REPL which will not produce further output until the connection is restarted.

This PR places a check around any code to be evaluated through Guile's and scheme's `eval-str` and yields an error message instead of hanging on an unparseable evaluation.