### PR TITLE
Prevent Guile REPL completions when eval is pending

### DIFF
--- a/fnl/conjure-spec/client/guile/socket_spec.fnl
+++ b/fnl/conjure-spec/client/guile/socket_spec.fnl
@@ -11,6 +11,10 @@
   [repl]
   (tset repl :status :connected))
 
+(fn set-repl-busy
+  [repl]
+  (tset repl :current "some command"))
+
 (describe "conjure.client.guile.socket"
   (fn []
     (tset package.loaded "conjure.remote.socket" fake-socket)
@@ -243,6 +247,29 @@
 
                 (guile.connect {})
                 (set-repl-connected fake-repl)
+                (guile.completions {:cb fake-callback :prefix "something"})
+                (guile.disconnect)
+
+                (assert.same [] calls)
+                (assert.same [] (. callback-results 1)))))
+
+        (it "Does not execute completions in REPL when connected but busy"
+            (fn []
+              (config.merge {:client {:guile {:socket
+                               {:pipename "fake-pipe" :host_port nil
+                                :enable_completions true}}}}
+                            {:overwrite? true})
+              (let [
+                    calls []
+                    spy-send (fn [call] (table.insert calls call))
+                    fake-repl {:send spy-send :status nil :destroy (fn [])}
+                    callback-results  []
+                    fake-callback (fn [result] (table.insert callback-results result))]
+                (fake-socket.set-fake-repl fake-repl)
+
+                (guile.connect {})
+                (set-repl-connected fake-repl)
+                (set-repl-busy fake-repl)
                 (guile.completions {:cb fake-callback :prefix "something"})
                 (guile.disconnect)
 

--- a/fnl/conjure/client/guile/socket.fnl
+++ b/fnl/conjure/client/guile/socket.fnl
@@ -233,6 +233,10 @@
     true
     false))
 
+(fn busy? []
+  (and (connected?) 
+       (. (state :repl) :current)))
+
 (fn M.on-exit []
   (M.disconnect))
 
@@ -250,7 +254,7 @@
 (fn M.completions [opts]
   ;(when (not= nil opts)
   ;  (log.append [(.. "; completions() called with: " (a.pr-str opts))] {:break? true}))
-  (if (and (completions-enabled?) (connected?))
+  (if (and (completions-enabled?) (connected?) (not (busy?)))
     (let [code (cmpl.build-completion-request opts.prefix)
           result-fn
           (fn [results]

--- a/lua/conjure-spec/client/guile/socket_spec.lua
+++ b/lua/conjure-spec/client/guile/socket_spec.lua
@@ -13,6 +13,10 @@ local function set_repl_connected(repl)
   repl["status"] = "connected"
   return nil
 end
+local function set_repl_busy(repl)
+  repl["current"] = "some command"
+  return nil
+end
 local function _2_()
   package.loaded["conjure.remote.socket"] = fake_socket
   local function _3_()
@@ -283,7 +287,35 @@ local function _2_()
       assert.same({}, calls)
       return assert.same({}, callback_results[1])
     end
-    return it("Does not execute completions in REPL when connected but completions disabled", _39_)
+    it("Does not execute completions in REPL when connected but completions disabled", _39_)
+    local function _43_()
+      config.merge({client = {guile = {socket = {pipename = "fake-pipe", host_port = nil, enable_completions = true}}}}, {["overwrite?"] = true})
+      local calls = {}
+      local spy_send
+      local function _44_(call)
+        return table.insert(calls, call)
+      end
+      spy_send = _44_
+      local fake_repl
+      local function _45_()
+      end
+      fake_repl = {send = spy_send, status = nil, destroy = _45_}
+      local callback_results = {}
+      local fake_callback
+      local function _46_(result)
+        return table.insert(callback_results, result)
+      end
+      fake_callback = _46_
+      fake_socket["set-fake-repl"](fake_repl)
+      guile.connect({})
+      set_repl_connected(fake_repl)
+      set_repl_busy(fake_repl)
+      guile.completions({cb = fake_callback, prefix = "something"})
+      guile.disconnect()
+      assert.same({}, calls)
+      return assert.same({}, callback_results[1])
+    end
+    return it("Does not execute completions in REPL when connected but busy", _43_)
   end
   return describe("enable completions config setting", _33_)
 end

--- a/lua/conjure/client/guile/socket.lua
+++ b/lua/conjure/client/guile/socket.lua
@@ -259,6 +259,9 @@ local function connected_3f()
     return false
   end
 end
+local function busy_3f()
+  return (connected_3f() and state("repl").current)
+end
 M["on-exit"] = function()
   return M.disconnect()
 end
@@ -273,7 +276,7 @@ M["on-filetype"] = function()
   return mapping.buf("GuileDisconnect", cfg({"mapping", "disconnect"}), _40_, {desc = "Disconnect from the REPL"})
 end
 M.completions = function(opts)
-  if (completions_enabled_3f() and connected_3f()) then
+  if (completions_enabled_3f() and connected_3f() and not busy_3f()) then
     local code = cmpl["build-completion-request"](opts.prefix)
     local result_fn
     local function _41_(results)


### PR DESCRIPTION
If the Guile REPL has a pending operation the REPL-based completions cannot not process resulting in nvim hanging. 

This PR places a check around the REPL state's `:current` state which represents the running evaluation.

Evaluating the following as a form or buffer will place the REPL in a state where it cannot process completions for 5 seconds, after which it will resume.

```
(sleep 5)
```

This branch will continue to operation (sans completions) until the evaluation completes or the REPL is disconnected/reconnected.