### PR TITLE
jump-to-latest: close-hud

### DIFF
--- a/fnl/conjure/log.fnl
+++ b/fnl/conjure/log.fnl
@@ -300,6 +300,7 @@
    :none nil})
 
 (fn jump-to-latest []
+  (close-hud)
   (let [buf (upsert-buf)
         last-eval-start (vim.api.nvim_buf_get_extmark_by_id
                           buf state.jump-to-latest.ns


### PR DESCRIPTION
When scrolling to latest with `<localleader>ll` it would be nice to close the hud at the same time.