### PR TITLE
Fix iw text object as iW to select school.lesson-6-message

### DIFF
--- a/fnl/conjure/school.fnl
+++ b/fnl/conjure/school.fnl
@@ -169,7 +169,7 @@
      ";; Wonderful!"
      ";; Visual evaluation is great for specific sections of a form."
      (.. ";; You can also evaluate a given motion with " (map-str :eval_motion))
-     (.. ";; Try " (map-str :eval_motion) "iw below to evaluate the word.")
+     (.. ";; Try " (map-str :eval_motion) "iW below to evaluate the word.")
      "school.lesson-6-message"
      ""
      (.. ";; Use " (map-str :eval_motion) "a( to evaluate the lesson form.")


### PR DESCRIPTION
Fix `iw` text object as `iW` to select `school.lesson-6-message` since `iw` doesn't select the dot `.` as it's not included in the definition of a vim "word".

<img width="3454" height="1894" alt="image" src="https://github.com/user-attachments/assets/b443c511-56a1-44b4-ab75-cbd6b95ac995" />
