### PR TITLE
cross file `jump to def` for Fennel (The nfnl client)

### DIFF
--- a/.nfnl.fnl
+++ b/.nfnl.fnl
@@ -1,5 +1,5 @@
-(local core (require :nfnl.core))
-(local config (require :nfnl.config))
+(local core (require :conjure.nfnl.core))
+(local config (require :conjure.nfnl.config))
 (local defaults (config.default))
 
 {:compiler-options (core.merge

--- a/fnl/conjure/client/fennel/def-str-util.fnl
+++ b/fnl/conjure/client/fennel/def-str-util.fnl
@@ -8,14 +8,6 @@
 (local config (autoload :nfnl.config))
 (local {: get-buf-content-as-string} (autoload :nfnl.nvim))
 
-(comment
-  ;; use `fennel.view` as pretty-print
-  ;; use `core.pr-str` as pretty-print
- (fennel.view {:a 15 :b 16})
- ;; use `notify.debug` as logging
- (notify.info "hello")
- )
-
 
 ;;TSQuery that matches `local, fn`
 (local def-query (vim-ts.query.parse :fennel
@@ -154,7 +146,6 @@
 
 (fn search-and-jump [code-text last-row]
   "Try jump in current file"
-  (print code-text last-row)
   (let [results (search-in-buffer code-text last-row 0)
         fnl-imports (imported-modules resolve-fnl-module-path last-row)]
     (if (> (length results) 0)
@@ -166,7 +157,6 @@
         (> (length fnl-imports) 0)
         ;; cross fnl module jump
         (do
-          (core.pr (length fnl-imports))
           (each [_ file-path (ipairs fnl-imports)]
           (let [code-text (remove-module-name code-text)
                 r (search-in-file code-text file-path)]

--- a/fnl/conjure/client/fennel/def-str-util.fnl
+++ b/fnl/conjure/client/fennel/def-str-util.fnl
@@ -1,0 +1,64 @@
+(local {: autoload} (require :conjure.nfnl.module))
+(local core (autoload :conjure.nfnl.core))
+(local conjure-ts (autoload :conjure.tree-sitter))
+(local ts-utils (autoload :nvim-treesitter.ts_utils))
+(local vim-ts (autoload :vim.treesitter))
+
+;;TSQuery that matches `local, fn`
+(local def-query (vim-ts.query.parse :fennel
+                                     "
+(local_form
+ (binding_pair
+   lhs: (symbol_binding) @local.def)) 
+(fn_form
+  name: [(symbol) (multi_symbol)] @fn.def)"))
+
+(fn prt [t]
+  (each [k v (pairs t)]
+    (if (not= (type v) :table)
+        (print k v)
+        (do
+          (print k)
+          (prt v)))))
+
+(fn get-current-root []
+  "Return the root-node of current buffer"
+  (let [bufnr 0
+        parser (vim-ts.get_parser bufnr)
+        tree (. (parser:parse) 1)]
+    (tree:root)))
+
+(fn search-targets [query root-node bufnr last]
+  "Based on the TS:Query, root-node, bufnr, list all the possible search targets"
+  ;; Return data like 
+  ;; [{:content "conjure-ts"
+  ;;   :node #<<node symbol_binding>>
+  ;;   :range {:end [2 16] :start [2 7]}}
+  ;;  ...
+  (let [bufnr (or bufnr 0)
+        last (or last (- 1))]
+    (icollect [id node (query:iter_captures root-node bufnr 0 last)]
+      (conjure-ts.node->table node))))
+
+(comment (search-targets def-query (get-current-root) 0 20))
+
+(fn search-and-jump [code-text last-row]
+  (let [curr-targets (search-targets def-query (get-current-root) 0 last-row)
+        results (core.filter (fn [node-t]
+                               (= code-text node-t.content))
+                             curr-targets)]
+    (if (> (length results) 0)
+        (do
+          (let [node (core.first results)
+                range node.range]
+            (vim.api.nvim_win_set_cursor 0 range.start))
+          results)
+        {:result "definition not found"})))
+
+(comment ;;
+  (search-and-jump :search-and-jump 39)
+  (search-and-jump :search-and-jump 49)
+  ;; 
+  )
+
+{: search-and-jump : search-targets : def-query : get-current-root}

--- a/fnl/conjure/client/fennel/def-str-util.fnl
+++ b/fnl/conjure/client/fennel/def-str-util.fnl
@@ -1,12 +1,8 @@
 (local {: autoload} (require :conjure.nfnl.module))
 (local core (autoload :conjure.nfnl.core))
 (local conjure-ts (autoload :conjure.tree-sitter))
-(local ts-utils (autoload :nvim-treesitter.ts_utils))
 (local vim-ts (autoload :vim.treesitter))
-(local fennel (autoload :nfnl.fennel))
-(local notify (autoload :nfnl.notify))
-(local config (autoload :nfnl.config))
-(local {: get-buf-content-as-string} (autoload :nfnl.nvim))
+(local config (autoload :conjure.nfnl.config))
 
 ;;TSQuery that matches `local, fn`
 (local def-query (vim-ts.query.parse :fennel

--- a/fnl/conjure/client/fennel/def-str-util.fnl
+++ b/fnl/conjure/client/fennel/def-str-util.fnl
@@ -4,35 +4,22 @@
 (local vim-ts (autoload :vim.treesitter))
 (local config (autoload :conjure.nfnl.config))
 (local notify (autoload :conjure.nfnl.notify))
+(local res (autoload :conjure.resources))
 
-;;TSQuery that matches `local, fn`
-(local def-local-query (vim-ts.query.parse :fennel
-                                     "
-(local_form
- (binding_pair
-   lhs: (symbol_binding) @local.def)) 
-(fn_form
-  name: [(symbol) (multi_symbol)] @local.fn.def)"))
+;;TSQuery that matches `local, fn, M.fn`
+(local def-local-query (vim-ts.query.parse
+                         :fennel
+                         (res.get-resource-contents "queries/fennel/local-def.scm")))
 
-(local def-ext-query (vim-ts.query.parse :fennel
-                                     "
-(local_form
- (binding_pair
-   lhs: (symbol_binding) @local.def)) 
-(fn_form
-  name: (symbol) @fn.def)
-(fn_form
-  name: (multi_symbol
-    member: (symbol_fragment) @fn.def))"))
+;;TSQuery that matches `local, fn, M.(fn) `
+(local def-ext-query (vim-ts.query.parse
+                       :fennel
+                       (res.get-resource-contents "queries/fennel/ext-def.scm")))
 
 ;;TSQuery that matches the module path imported by `require, autoload`
-(local path-query (vim-ts.query.parse :fennel
-                                      "
-(local_form
-  (binding_pair
-    rhs: (list
-           call: (symbol) (#any-of? \"autoload\" \"require\")
-           item: (string) @import.path)))"))
+(local path-query (vim-ts.query.parse
+                    :fennel
+                    (res.get-resource-contents "queries/fennel/import-path.scm")))
 
 (fn get-current-root [bufnr lang]
   "Return the root-node of bufnr or current buffer"
@@ -215,4 +202,4 @@
   )
 
 {: search-and-jump : search-targets : get-current-root : def-local-query : def-ext-query
- : imported-modules : resolve-fnl-module-path}
+ : path-query : imported-modules : resolve-fnl-module-path}

--- a/fnl/conjure/client/fennel/def-str-util.fnl
+++ b/fnl/conjure/client/fennel/def-str-util.fnl
@@ -12,7 +12,10 @@
  (binding_pair
    lhs: (symbol_binding) @local.def)) 
 (fn_form
-  name: [(symbol) (multi_symbol)] @fn.def)"))
+  name: (symbol) @fn.def)
+(fn_form
+  name: (multi_symbol
+    member: (symbol_fragment) @fn.def))"))
 
 ;;TSQuery that matches the module path imported by `require, autoload`
 (local path-query (vim-ts.query.parse :fennel
@@ -139,7 +142,8 @@
 (fn search-and-jump [code-text last-row]
   "Try jump in local file and fennel modules"
   (notify.debug (.. "code-text: " code-text))
-  (let [results (search-in-buffer code-text last-row 0)
+  (let [code-text (remove-module-name code-text)
+        results (search-in-buffer code-text last-row 0)
         fnl-imports (imported-modules resolve-fnl-module-path last-row)]
     (if (> (length results) 0) ;; local jump
         (do
@@ -152,8 +156,7 @@
           (notify.debug (.. "fnl-path: " (. (config.default) :fennel-path)))
           (notify.debug (.. "search symbol in the following fnl libs: " (core.pr-str fnl-imports)))
           (each [_ file-path (ipairs fnl-imports)]
-            (let [code-text (remove-module-name code-text)
-                  r (search-in-ext-file code-text file-path)]
+            (let [r (search-in-ext-file code-text file-path)]
               (notify.debug (.. "search in file-path: " file-path " for code-text " code-text))
               (when r (lua "return r"))))
           {:result "definition not found"}))))

--- a/fnl/conjure/client/fennel/def-str-util.fnl
+++ b/fnl/conjure/client/fennel/def-str-util.fnl
@@ -49,7 +49,7 @@
                              curr-targets)]
     (if (> (length results) 0)
         (do
-          (let [node (core.first results)
+          (let [node (core.last results)
                 range node.range]
             (vim.api.nvim_win_set_cursor 0 range.start))
           results)

--- a/fnl/conjure/client/fennel/def-str-util.fnl
+++ b/fnl/conjure/client/fennel/def-str-util.fnl
@@ -111,7 +111,7 @@
            (rest-str node_t.content))
   (imported-modules resolve-fnl-module-path -1))
 
-(fn search-in-file [code-text file-path]
+(fn search-in-ext-file [code-text file-path]
   "Open file-path buffer, search for code-text, and jump if found."
   (let [bufnr (vim.fn.bufadd file-path)]
     (vim.fn.bufload bufnr)
@@ -130,7 +130,7 @@
   (vim.fn.bufload bufnr)
   (search-ext-targets def-query (get-current-root bufnr :fennel) bufnr)
   (search-in-ext-buffer :debug -1 bufnr)
-  (search-in-file :debug f))
+  (search-in-ext-file :debug f))
 
 (fn remove-module-name [s]
   (let [(start-index end-index) (string.find s "%.")]
@@ -139,7 +139,7 @@
         s)))
 
 (fn search-and-jump [code-text last-row]
-  "Try jump in current file"
+  "Try jump in local file and fennel modules"
   (let [results (search-in-buffer code-text last-row 0)
         fnl-imports (imported-modules resolve-fnl-module-path last-row)]
     (if (> (length results) 0) ;; local jump
@@ -151,7 +151,7 @@
         (do
           (each [_ file-path (ipairs fnl-imports)]
             (let [code-text (remove-module-name code-text)
-                  r (search-in-file code-text file-path)]
+                  r (search-in-ext-file code-text file-path)]
               (when r (lua "return r"))))
           {:result "definition not found"}))))
 

--- a/fnl/conjure/client/fennel/def-str-util.fnl
+++ b/fnl/conjure/client/fennel/def-str-util.fnl
@@ -3,6 +3,17 @@
 (local conjure-ts (autoload :conjure.tree-sitter))
 (local ts-utils (autoload :nvim-treesitter.ts_utils))
 (local vim-ts (autoload :vim.treesitter))
+(local fennel (autoload :nfnl.fennel))
+(local notify (autoload :nfnl.notify))
+
+(comment
+  ;; use `fennel.view` as pretty-print
+  ;; use `core.pr-str` as pretty-print
+ (fennel.view {:a 15 :b 16})
+ ;; use `notify.debug` as logging
+ (notify.info "hello")
+ )
+
 
 ;;TSQuery that matches `local, fn`
 (local def-query (vim-ts.query.parse :fennel
@@ -21,14 +32,6 @@
     rhs: (list
            call: (symbol) (#any-of? \"autoload\" \"require\")
            item: (string) @import.path)))"))
-
-(fn prt [t]
-  (each [k v (pairs t)]
-    (if (not= (type v) :table)
-        (print k v)
-        (do
-          (print k)
-          (prt v)))))
 
 (fn get-current-root []
   "Return the root-node of current buffer"

--- a/fnl/conjure/client/fennel/def-str-util.fnl
+++ b/fnl/conjure/client/fennel/def-str-util.fnl
@@ -5,6 +5,7 @@
 (local vim-ts (autoload :vim.treesitter))
 (local fennel (autoload :nfnl.fennel))
 (local notify (autoload :nfnl.notify))
+(local config (autoload :nfnl.config))
 
 (comment
   ;; use `fennel.view` as pretty-print
@@ -75,7 +76,7 @@
 
 (fn resolve-fnl-module-path [modname]
   "Try to resolve a fnl module via fennel.path"
-  (package.searchpath modname fennel.path))
+  (package.searchpath modname (. (config.default) :fennel-path)))
 
 
 (fn imported-modules [resolve last-row]
@@ -106,13 +107,12 @@
         (core.last cross-results)))))
 
 (comment
+;; TODO: fix from search-in-file 
 (local f 
  "/Users/laurencechen/.local/share/nvim/plugged/nfnl/fnl/nfnl/notify.fnl"
   )
 (search-in-file "debug" f)
 )
- 
-  
 
 (fn search-and-jump [code-text last-row]
   "Try jump in current file"

--- a/fnl/conjure/client/fennel/nfnl.fnl
+++ b/fnl/conjure/client/fennel/nfnl.fnl
@@ -11,18 +11,27 @@
 (local fs (autoload :conjure.nfnl.fs))
 (local def-str-util (autoload :conjure.client.fennel.def-str-util))
 
-(local M (define :conjure.client.fennel.nfnl
-           {:comment-node? ts.lisp-comment-node?
-            :buf-suffix :.fnl
-            :comment-prefix "; "}))
+(local M
+  (define :conjure.client.fennel.nfnl
+    {:comment-node? ts.lisp-comment-node?
+     :buf-suffix ".fnl"
+     :comment-prefix "; "}))
 
 (fn M.form-node? [node]
   (ts.node-surrounded-by-form-pair-chars? node [["#(" ")"]]))
 
-(config.merge {:client {:fennel {:nfnl {}}}})
+(config.merge
+  {:client
+   {:fennel
+    {:nfnl
+     {}}}})
 
 (when (config.get-in [:mapping :enable_defaults])
-  (config.merge {:client {:fennel {:nfnl {:mapping {}}}}}))
+  (config.merge
+   {:client
+    {:fennel
+     {:nfnl
+      {:mapping {}}}}}))
 
 (local cfg (config.get-in-fn [:client :fennel :nfnl]))
 
@@ -32,18 +41,20 @@
   "Upserts a repl for the given path. Stored in the `repls` table.
   TODO: Add mappings or commands that allow us to reset the REPL state if they get stuck."
   (if (?. M.repls path)
-      (. M.repls path)
-      (let [r (repl.new {:on-error (fn [err-type err]
-                                     (-> (str.join ["[" err-type "] " err])
-                                         (text.strip-ansi-escape-sequences)
-                                         (str.trim)
-                                         (text.prefixed-lines "; ")
-                                         (log.append)))
-                         :cfg (let [config-map (nfnl-config.find-and-load (fs.file-name-root path))]
-                                (when config-map
-                                  (nfnl-config.cfg-fn config-map)))})]
-        (tset M.repls path r)
-        r)))
+    (. M.repls path)
+    (let [r (repl.new
+              {:on-error
+               (fn [err-type err]
+                 (-> (str.join ["[" err-type "] " err])
+                     (text.strip-ansi-escape-sequences)
+                     (str.trim)
+                     (text.prefixed-lines "; ")
+                     (log.append)))
+               :cfg (let [config-map (nfnl-config.find-and-load (fs.file-name-root path))]
+                      (when config-map
+                        (nfnl-config.cfg-fn config-map)))})]
+      (tset M.repls path r)
+      r)))
 
 (fn M.module-path [path]
   "Turns a full file path into a dot.delimited.module.path. We can then use this module path to perform live reloads by modifying the currently loaded module.
@@ -53,11 +64,12 @@
   TODO: Make this configurable so that non-standard Fennel setups also work. Maybe just read the .nfnl.fnl configuration since that is what we are supposed to be working with."
   (when path
     (let [parts (-> path (fs.file-name-root) (fs.split-path))
-          fnl-and-below (core.drop-while #(not= $1 :fnl) parts)]
-      (when (= :fnl (core.first fnl-and-below))
+          fnl-and-below (core.drop-while #(not= $1 "fnl") parts)]
+      (when (= "fnl" (core.first fnl-and-below))
         (str.join "." (core.rest fnl-and-below))))))
 
-(comment (M.module-path "~/repos/Olical/conjure/fnl/conjure/client/fennel/nfnl.fnl"))
+(comment
+  (M.module-path "~/repos/Olical/conjure/fnl/conjure/client/fennel/nfnl.fnl"))
 
 (fn M.eval-str [opts]
   "Client function, called by Conjure when evaluating a string."
@@ -65,16 +77,20 @@
         results (repl (.. opts.code "\n"))
         result-strs (core.map fennel.view results)
         mod-path (M.module-path opts.file-path)]
+
     ;; When we evaluate a whole file and it ends in a table, we merge that table into the loaded module.
     ;; This allows you to reload a module with ef or eb.
-    (when (and mod-path (or (= :buf opts.origin) (= :file opts.origin))
+    (when (and mod-path
+               (or (= :buf opts.origin) (= :file opts.origin))
                (core.table? (core.last results)))
       (let [mod (core.get package.loaded mod-path)]
         (tset package.loaded mod-path (core.merge! mod (core.last results)))))
+
     (when (not (core.empty? result-strs))
       (let [result (str.join "\n" result-strs)]
         (when opts.on-result
           (opts.on-result result))
+
         (log.append (text.split-lines result))))))
 
 (fn M.eval-file [opts]

--- a/fnl/conjure/client/fennel/nfnl.fnl
+++ b/fnl/conjure/client/fennel/nfnl.fnl
@@ -110,12 +110,4 @@
       (def-str-util.search-and-jump opts.code (. opts.range.start 1))
       (log.append ["jump to def is not supported because treesitter is not enabled or installed"])))
 
-(comment ;; testing code for def-str
-  (M.eval-file :dafa)
-  (def-str-util.search-and-jump :M.eval-file 99)
-  (def-str-util.search-targets def-str-util.def-query
-    (def-str-util.get-current-root)
-    0
-    99))
-
 M

--- a/lua/conjure/client/fennel/def-str-util.lua
+++ b/lua/conjure/client/fennel/def-str-util.lua
@@ -6,6 +6,7 @@ local conjure_ts = autoload("conjure.tree-sitter")
 local ts_utils = autoload("nvim-treesitter.ts_utils")
 local vim_ts = autoload("vim.treesitter")
 local def_query = vim_ts.query.parse("fennel", "\n(local_form\n (binding_pair\n   lhs: (symbol_binding) @local.def)) \n(fn_form\n  name: [(symbol) (multi_symbol)] @fn.def)")
+local path_query = vim_ts.query.parse("fennel", "\n(local_form\n  (binding_pair\n    rhs: (list\n           call: (symbol) (#any-of? \"autoload\" \"require\")\n           item: (string) @import.path)))")
 local function prt(t)
   for k, v in pairs(t) do
     if (type(v) ~= "table") then
@@ -26,31 +27,37 @@ end
 local function search_targets(query, root_node, bufnr, last)
   local bufnr0 = (bufnr or 0)
   local last0 = (last or ( - 1))
-  local tbl_21_auto = {}
-  local i_22_auto = 0
+  local tbl_21_ = {}
+  local i_22_ = 0
   for id, node in query:iter_captures(root_node, bufnr0, 0, last0) do
-    local val_23_auto = conjure_ts["node->table"](node)
-    if (nil ~= val_23_auto) then
-      i_22_auto = (i_22_auto + 1)
-      tbl_21_auto[i_22_auto] = val_23_auto
+    local val_23_ = conjure_ts["node->table"](node)
+    if (nil ~= val_23_) then
+      i_22_ = (i_22_ + 1)
+      tbl_21_[i_22_] = val_23_
     else
     end
   end
-  return tbl_21_auto
+  return tbl_21_
 end
 --[[ (search-targets def-query (get-current-root) 0 20) ]]
-local function search_and_jump(code_text, last_row)
-  local curr_targets = search_targets(def_query, get_current_root(), 0, last_row)
+local function search_in_buffer(code_text, last_row, bufnr)
+  local curr_targets = search_targets(def_query, get_current_root(), bufnr, last_row)
   local results
   local function _4_(node_t)
     return (code_text == node_t.content)
   end
   results = core.filter(_4_, curr_targets)
+  return results
+end
+local function jump_to_range(range)
+  return vim.api.nvim_win_set_cursor(0, range.start)
+end
+local function search_and_jump(code_text, last_row)
+  local results = search_in_buffer(code_text, last_row, 0)
   if (#results > 0) then
     do
       local node = core.last(results)
-      local range = node.range
-      vim.api.nvim_win_set_cursor(0, range.start)
+      jump_to_range(node.range)
     end
     return results
   else
@@ -58,4 +65,40 @@ local function search_and_jump(code_text, last_row)
   end
 end
 --[[ (search-and-jump "search-and-jump" 39) (search-and-jump "search-and-jump" 49) ]]
+local function rest_str(s)
+  return string.sub(s, 2, -1)
+end
+--[[ (icollect [id node_t (ipairs (search-targets path-query (get-current-root) 0 30))] (rest-str node_t.content)) ]]
+local function resolve_module_path(modname)
+  return package.searchpath(modname, package.path)
+end
+local function imported_modules()
+  local root = get_current_root()
+  local raw_mods
+  do
+    local tbl_21_ = {}
+    local i_22_ = 0
+    for _, node_t in ipairs(search_targets(path_query, root, 0, 200)) do
+      local val_23_ = rest_str(node_t.content)
+      if (nil ~= val_23_) then
+        i_22_ = (i_22_ + 1)
+        tbl_21_[i_22_] = val_23_
+      else
+      end
+    end
+    raw_mods = tbl_21_
+  end
+  local tbl_21_ = {}
+  local i_22_ = 0
+  for _, m in ipairs(raw_mods) do
+    local val_23_ = resolve_module_path(m)
+    if (nil ~= val_23_) then
+      i_22_ = (i_22_ + 1)
+      tbl_21_[i_22_] = val_23_
+    else
+    end
+  end
+  return tbl_21_
+end
+imported_modules()
 return {["search-and-jump"] = search_and_jump, ["search-targets"] = search_targets, ["def-query"] = def_query, ["get-current-root"] = get_current_root}

--- a/lua/conjure/client/fennel/def-str-util.lua
+++ b/lua/conjure/client/fennel/def-str-util.lua
@@ -5,19 +5,11 @@ local core = autoload("conjure.nfnl.core")
 local conjure_ts = autoload("conjure.tree-sitter")
 local ts_utils = autoload("nvim-treesitter.ts_utils")
 local vim_ts = autoload("vim.treesitter")
+local fennel = autoload("nfnl.fennel")
+local notify = autoload("nfnl.notify")
+--[[ (fennel.view {:a 15 :b 16}) (notify.info "hello") ]]
 local def_query = vim_ts.query.parse("fennel", "\n(local_form\n (binding_pair\n   lhs: (symbol_binding) @local.def)) \n(fn_form\n  name: [(symbol) (multi_symbol)] @fn.def)")
 local path_query = vim_ts.query.parse("fennel", "\n(local_form\n  (binding_pair\n    rhs: (list\n           call: (symbol) (#any-of? \"autoload\" \"require\")\n           item: (string) @import.path)))")
-local function prt(t)
-  for k, v in pairs(t) do
-    if (type(v) ~= "table") then
-      print(k, v)
-    else
-      print(k)
-      prt(v)
-    end
-  end
-  return nil
-end
 local function get_current_root()
   local bufnr = 0
   local parser = vim_ts.get_parser(bufnr)
@@ -43,10 +35,10 @@ end
 local function search_in_buffer(code_text, last_row, bufnr)
   local curr_targets = search_targets(def_query, get_current_root(), bufnr, last_row)
   local results
-  local function _4_(node_t)
+  local function _3_(node_t)
     return (code_text == node_t.content)
   end
-  results = core.filter(_4_, curr_targets)
+  results = core.filter(_3_, curr_targets)
   return results
 end
 local function jump_to_range(range)

--- a/lua/conjure/client/fennel/def-str-util.lua
+++ b/lua/conjure/client/fennel/def-str-util.lua
@@ -8,38 +8,74 @@ local vim_ts = autoload("vim.treesitter")
 local fennel = autoload("nfnl.fennel")
 local notify = autoload("nfnl.notify")
 local config = autoload("nfnl.config")
+local _local_2_ = autoload("nfnl.nvim")
+local get_buf_content_as_string = _local_2_["get-buf-content-as-string"]
 --[[ (fennel.view {:a 15 :b 16}) (notify.info "hello") ]]
 local def_query = vim_ts.query.parse("fennel", "\n(local_form\n (binding_pair\n   lhs: (symbol_binding) @local.def)) \n(fn_form\n  name: [(symbol) (multi_symbol)] @fn.def)")
 local path_query = vim_ts.query.parse("fennel", "\n(local_form\n  (binding_pair\n    rhs: (list\n           call: (symbol) (#any-of? \"autoload\" \"require\")\n           item: (string) @import.path)))")
-local function get_current_root()
-  local bufnr = 0
-  local parser = vim_ts.get_parser(bufnr)
+local function get_current_root(bufnr, lang)
+  local bufnr0 = (bufnr or 0)
+  local lang0 = (lang or "fennel")
+  local parser = vim_ts.get_parser(bufnr0, lang0)
   local tree = parser:parse()[1]
   return tree:root()
 end
 local function search_targets(query, root_node, bufnr, last)
   local bufnr0 = (bufnr or 0)
   local last0 = (last or ( - 1))
-  local tbl_21_auto = {}
-  local i_22_auto = 0
+  local tbl_21_ = {}
+  local i_22_ = 0
   for id, node in query:iter_captures(root_node, bufnr0, 0, last0) do
-    local val_23_auto = conjure_ts["node->table"](node)
-    if (nil ~= val_23_auto) then
-      i_22_auto = (i_22_auto + 1)
-      tbl_21_auto[i_22_auto] = val_23_auto
+    local val_23_ = conjure_ts["node->table"](node)
+    if (nil ~= val_23_) then
+      i_22_ = (i_22_ + 1)
+      tbl_21_[i_22_] = val_23_
     else
     end
   end
-  return tbl_21_auto
+  return tbl_21_
 end
 --[[ (search-targets def-query (get-current-root) 0 20) ]]
 local function search_in_buffer(code_text, last_row, bufnr)
-  local curr_targets = search_targets(def_query, get_current_root(), bufnr, last_row)
+  local curr_targets = search_targets(def_query, get_current_root(bufnr), bufnr, last_row)
   local results
-  local function _3_(node_t)
+  local function _4_(node_t)
     return (code_text == node_t.content)
   end
-  results = core.filter(_3_, curr_targets)
+  results = core.filter(_4_, curr_targets)
+  return results
+end
+local function search_ext_targets(query, root_node, bufnr, last)
+  local last0 = (last or -1)
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  local tbl_21_ = {}
+  local i_22_ = 0
+  for id, node in query:iter_captures(root_node, bufnr, 0, last0) do
+    local val_23_
+    do
+      local range = conjure_ts.range(node)
+      local start_row = core["get-in"](range, {"start", 1})
+      local start_col = core["get-in"](range, {"start", 2})
+      local end_row = core["get-in"](range, {"end", 1})
+      local end_col = core["get-in"](range, {"end", 2})
+      local content = string.sub(core.get(lines, start_row), (1 + start_col), (1 + end_col))
+      val_23_ = {content = content, range = range}
+    end
+    if (nil ~= val_23_) then
+      i_22_ = (i_22_ + 1)
+      tbl_21_[i_22_] = val_23_
+    else
+    end
+  end
+  return tbl_21_
+end
+local function search_in_ext_buffer(code_text, last_row, bufnr)
+  local curr_targets = search_ext_targets(def_query, get_current_root(bufnr), bufnr, last_row)
+  local results
+  local function _6_(node_t)
+    return (code_text == node_t.content)
+  end
+  results = core.filter(_6_, curr_targets)
   return results
 end
 local function jump_to_range(range)
@@ -58,45 +94,55 @@ local function imported_modules(resolve, last_row)
   local root = get_current_root()
   local raw_mods
   do
-    local tbl_21_auto = {}
-    local i_22_auto = 0
+    local tbl_21_ = {}
+    local i_22_ = 0
     for _, node_t in ipairs(search_targets(path_query, root, 0, last_row)) do
-      local val_23_auto = rest_str(node_t.content)
-      if (nil ~= val_23_auto) then
-        i_22_auto = (i_22_auto + 1)
-        tbl_21_auto[i_22_auto] = val_23_auto
+      local val_23_ = rest_str(node_t.content)
+      if (nil ~= val_23_) then
+        i_22_ = (i_22_ + 1)
+        tbl_21_[i_22_] = val_23_
       else
       end
     end
-    raw_mods = tbl_21_auto
+    raw_mods = tbl_21_
   end
-  local tbl_21_auto = {}
-  local i_22_auto = 0
+  local tbl_21_ = {}
+  local i_22_ = 0
   for _, m in ipairs(raw_mods) do
-    local val_23_auto = resolve(m)
-    if (nil ~= val_23_auto) then
-      i_22_auto = (i_22_auto + 1)
-      tbl_21_auto[i_22_auto] = val_23_auto
+    local val_23_ = resolve(m)
+    if (nil ~= val_23_) then
+      i_22_ = (i_22_ + 1)
+      tbl_21_[i_22_] = val_23_
     else
     end
   end
-  return tbl_21_auto
+  return tbl_21_
 end
 --[[ (icollect [id node_t (ipairs (search-targets path-query (get-current-root) 0 30))] (rest-str node_t.content)) (imported-modules resolve-fnl-module-path -1) ]]
 local function search_in_file(code_text, file_path)
-  local buf = vim.fn.bufadd(file_path)
-  vim.fn.bufload(buf)
-  local cross_results = search_in_buffer(code_text, -1, buf)
+  local bufnr = vim.fn.bufadd(file_path)
+  vim.fn.bufload(bufnr)
+  local cross_results = search_in_ext_buffer(code_text, -1, bufnr)
   if (#cross_results > 0) then
-    vim.api.nvim_set_current_buf(buf)
+    vim.api.nvim_set_current_buf(bufnr)
     jump_to_range(core.last(cross_results).range)
-    return core.last(cross_results)
+    core.last(cross_results)
+    return 1
   else
-    return nil
+  end
+  return vim.api.nvim_buf_delete(bufnr, {})
+end
+--[[ (local f "/Users/laurencechen/.local/share/nvim/plugged/nfnl/fnl/nfnl/notify.fnl") (local bufnr (vim.fn.bufadd f)) (vim.fn.bufload bufnr) (search-ext-targets def-query (get-current-root bufnr "fennel") bufnr) (search-in-ext-buffer "debug" -1 bufnr) (search-in-file "debug" f) ]]
+local function remove_module_name(s)
+  local start_index, end_index = string.find(s, "%.")
+  if start_index then
+    return string.sub(s, (1 + start_index))
+  else
+    return s
   end
 end
---[[ (local f "/Users/laurencechen/.local/share/nvim/plugged/nfnl/fnl/nfnl/notify.fnl") (search-in-file "debug" f) ]]
 local function search_and_jump(code_text, last_row)
+  print(code_text, last_row)
   local results = search_in_buffer(code_text, last_row, 0)
   local fnl_imports = imported_modules(resolve_fnl_module_path, last_row)
   if (#results > 0) then
@@ -106,8 +152,10 @@ local function search_and_jump(code_text, last_row)
     end
     return results
   elseif (#fnl_imports > 0) then
+    core.pr(#fnl_imports)
     for _, file_path in ipairs(fnl_imports) do
-      local r = search_in_file(code_text, file_path)
+      local code_text0 = remove_module_name(code_text)
+      local r = search_in_file(code_text0, file_path)
       if r then
         return r
       else

--- a/lua/conjure/client/fennel/def-str-util.lua
+++ b/lua/conjure/client/fennel/def-str-util.lua
@@ -6,7 +6,7 @@ local conjure_ts = autoload("conjure.tree-sitter")
 local vim_ts = autoload("vim.treesitter")
 local config = autoload("conjure.nfnl.config")
 local notify = autoload("conjure.nfnl.notify")
-local def_query = vim_ts.query.parse("fennel", "\n(local_form\n (binding_pair\n   lhs: (symbol_binding) @local.def)) \n(fn_form\n  name: [(symbol) (multi_symbol)] @fn.def)")
+local def_query = vim_ts.query.parse("fennel", "\n(local_form\n (binding_pair\n   lhs: (symbol_binding) @local.def)) \n(fn_form\n  name: (symbol) @fn.def)\n(fn_form\n  name: (multi_symbol\n    member: (symbol_fragment) @fn.def))")
 local path_query = vim_ts.query.parse("fennel", "\n(local_form\n  (binding_pair\n    rhs: (list\n           call: (symbol) (#any-of? \"autoload\" \"require\")\n           item: (string) @import.path)))")
 local function get_current_root(bufnr, lang)
   local bufnr0 = (bufnr or 0)
@@ -18,17 +18,17 @@ end
 local function search_targets(query, root_node, bufnr, last)
   local bufnr0 = (bufnr or 0)
   local last0 = (last or ( - 1))
-  local tbl_21_ = {}
-  local i_22_ = 0
+  local tbl_21_auto = {}
+  local i_22_auto = 0
   for id, node in query:iter_captures(root_node, bufnr0, 0, last0) do
-    local val_23_ = conjure_ts["node->table"](node)
-    if (nil ~= val_23_) then
-      i_22_ = (i_22_ + 1)
-      tbl_21_[i_22_] = val_23_
+    local val_23_auto = conjure_ts["node->table"](node)
+    if (nil ~= val_23_auto) then
+      i_22_auto = (i_22_auto + 1)
+      tbl_21_auto[i_22_auto] = val_23_auto
     else
     end
   end
-  return tbl_21_
+  return tbl_21_auto
 end
 --[[ (search-targets def-query (get-current-root) 0 20) ]]
 local function search_in_buffer(code_text, last_row, bufnr)
@@ -43,10 +43,10 @@ end
 local function search_ext_targets(query, root_node, bufnr, last)
   local last0 = (last or -1)
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-  local tbl_21_ = {}
-  local i_22_ = 0
+  local tbl_21_auto = {}
+  local i_22_auto = 0
   for id, node in query:iter_captures(root_node, bufnr, 0, last0) do
-    local val_23_
+    local val_23_auto
     do
       local range = conjure_ts.range(node)
       local start_row = core["get-in"](range, {"start", 1})
@@ -54,15 +54,15 @@ local function search_ext_targets(query, root_node, bufnr, last)
       local end_row = core["get-in"](range, {"end", 1})
       local end_col = core["get-in"](range, {"end", 2})
       local content = string.sub(core.get(lines, start_row), (1 + start_col), (1 + end_col))
-      val_23_ = {content = content, range = range}
+      val_23_auto = {content = content, range = range}
     end
-    if (nil ~= val_23_) then
-      i_22_ = (i_22_ + 1)
-      tbl_21_[i_22_] = val_23_
+    if (nil ~= val_23_auto) then
+      i_22_auto = (i_22_auto + 1)
+      tbl_21_auto[i_22_auto] = val_23_auto
     else
     end
   end
-  return tbl_21_
+  return tbl_21_auto
 end
 local function search_in_ext_buffer(code_text, last_row, bufnr)
   local curr_targets = search_ext_targets(def_query, get_current_root(bufnr), bufnr, last_row)
@@ -89,30 +89,30 @@ local function imported_modules(resolve, last_row)
   local root = get_current_root()
   local raw_mods
   do
-    local tbl_21_ = {}
-    local i_22_ = 0
+    local tbl_21_auto = {}
+    local i_22_auto = 0
     for _, node_t in ipairs(search_targets(path_query, root, 0, last_row)) do
-      local val_23_ = rest_str(node_t.content)
-      if (nil ~= val_23_) then
-        i_22_ = (i_22_ + 1)
-        tbl_21_[i_22_] = val_23_
+      local val_23_auto = rest_str(node_t.content)
+      if (nil ~= val_23_auto) then
+        i_22_auto = (i_22_auto + 1)
+        tbl_21_auto[i_22_auto] = val_23_auto
       else
       end
     end
-    raw_mods = tbl_21_
+    raw_mods = tbl_21_auto
   end
   notify.debug(("raw-mods: " .. core["pr-str"](raw_mods)))
-  local tbl_21_ = {}
-  local i_22_ = 0
+  local tbl_21_auto = {}
+  local i_22_auto = 0
   for _, m in ipairs(raw_mods) do
-    local val_23_ = resolve(m)
-    if (nil ~= val_23_) then
-      i_22_ = (i_22_ + 1)
-      tbl_21_[i_22_] = val_23_
+    local val_23_auto = resolve(m)
+    if (nil ~= val_23_auto) then
+      i_22_auto = (i_22_auto + 1)
+      tbl_21_auto[i_22_auto] = val_23_auto
     else
     end
   end
-  return tbl_21_
+  return tbl_21_auto
 end
 --[[ (icollect [id node_t (ipairs (search-targets path-query (get-current-root) 0 30))] (rest-str node_t.content)) (imported-modules resolve-fnl-module-path -1) ]]
 local function search_in_ext_file(code_text, file_path)
@@ -139,7 +139,8 @@ local function remove_module_name(s)
 end
 local function search_and_jump(code_text, last_row)
   notify.debug(("code-text: " .. code_text))
-  local results = search_in_buffer(code_text, last_row, 0)
+  local code_text0 = remove_module_name(code_text)
+  local results = search_in_buffer(code_text0, last_row, 0)
   local fnl_imports = imported_modules(resolve_fnl_module_path, last_row)
   if (#results > 0) then
     do
@@ -152,7 +153,6 @@ local function search_and_jump(code_text, last_row)
     notify.debug(("fnl-path: " .. config.default()["fennel-path"]))
     notify.debug(("search symbol in the following fnl libs: " .. core["pr-str"](fnl_imports)))
     for _, file_path in ipairs(fnl_imports) do
-      local code_text0 = remove_module_name(code_text)
       local r = search_in_ext_file(code_text0, file_path)
       notify.debug(("search in file-path: " .. file_path .. " for code-text " .. code_text0))
       if r then

--- a/lua/conjure/client/fennel/def-str-util.lua
+++ b/lua/conjure/client/fennel/def-str-util.lua
@@ -123,10 +123,11 @@ local function search_in_ext_file(code_text, file_path)
     vim.api.nvim_set_current_buf(bufnr)
     jump_to_range(core.last(cross_results).range)
     core.last(cross_results)
-    return 1
+    return true
   else
+    vim.api.nvim_buf_delete(bufnr, {})
+    return false
   end
-  return vim.api.nvim_buf_delete(bufnr, {})
 end
 --[[ (local f "/Users/laurencechen/.local/share/nvim/plugged/nfnl/fnl/nfnl/notify.fnl") (local bufnr (vim.fn.bufadd f)) (vim.fn.bufload bufnr) (search-ext-targets def-query (get-current-root bufnr "fennel") bufnr) (search-in-ext-buffer "debug" -1 bufnr) (search-in-ext-file "debug" f) ]]
 local function remove_module_name(s)
@@ -161,15 +162,17 @@ local function search_and_jump(code_text, last_row)
     notify.debug("begin cross fnl module jump")
     notify.debug(("fnl-path: " .. config.default()["fennel-path"]))
     notify.debug(("search symbol in the following fnl libs: " .. core["pr-str"](r_fnl_imports)))
+    local results0 = {}
     for _, file_path in ipairs(r_fnl_imports) do
       local r = search_in_ext_file(code_text0, file_path)
-      notify.debug(("search in file-path: " .. file_path .. " for code-text " .. code_text0))
-      if r then
-        return r
-      else
-      end
+      notify.debug(("search in file-path: " .. file_path .. " for code-text " .. code_text0 .. " result " .. tostring(r)))
+      table.insert(results0, r)
     end
-    return {result = "definition not found"}
+    if not core.some(core.identity, results0) then
+      return {result = "definition not found"}
+    else
+      return nil
+    end
   else
     return nil
   end

--- a/lua/conjure/client/fennel/def-str-util.lua
+++ b/lua/conjure/client/fennel/def-str-util.lua
@@ -7,6 +7,7 @@ local ts_utils = autoload("nvim-treesitter.ts_utils")
 local vim_ts = autoload("vim.treesitter")
 local fennel = autoload("nfnl.fennel")
 local notify = autoload("nfnl.notify")
+local config = autoload("nfnl.config")
 --[[ (fennel.view {:a 15 :b 16}) (notify.info "hello") ]]
 local def_query = vim_ts.query.parse("fennel", "\n(local_form\n (binding_pair\n   lhs: (symbol_binding) @local.def)) \n(fn_form\n  name: [(symbol) (multi_symbol)] @fn.def)")
 local path_query = vim_ts.query.parse("fennel", "\n(local_form\n  (binding_pair\n    rhs: (list\n           call: (symbol) (#any-of? \"autoload\" \"require\")\n           item: (string) @import.path)))")
@@ -51,7 +52,7 @@ local function resolve_lua_module_path(modname)
   return package.searchpath(("lua." .. modname), package.path)
 end
 local function resolve_fnl_module_path(modname)
-  return package.searchpath(modname, fennel.path)
+  return package.searchpath(modname, config.default()["fennel-path"])
 end
 local function imported_modules(resolve, last_row)
   local root = get_current_root()

--- a/lua/conjure/client/fennel/def-str-util.lua
+++ b/lua/conjure/client/fennel/def-str-util.lua
@@ -6,7 +6,8 @@ local conjure_ts = autoload("conjure.tree-sitter")
 local vim_ts = autoload("vim.treesitter")
 local config = autoload("conjure.nfnl.config")
 local notify = autoload("conjure.nfnl.notify")
-local def_query = vim_ts.query.parse("fennel", "\n(local_form\n (binding_pair\n   lhs: (symbol_binding) @local.def)) \n(fn_form\n  name: (symbol) @fn.def)\n(fn_form\n  name: (multi_symbol\n    member: (symbol_fragment) @fn.def))")
+local def_local_query = vim_ts.query.parse("fennel", "\n(local_form\n (binding_pair\n   lhs: (symbol_binding) @local.def)) \n(fn_form\n  name: [(symbol) (multi_symbol)] @local.fn.def)")
+local def_ext_query = vim_ts.query.parse("fennel", "\n(local_form\n (binding_pair\n   lhs: (symbol_binding) @local.def)) \n(fn_form\n  name: (symbol) @fn.def)\n(fn_form\n  name: (multi_symbol\n    member: (symbol_fragment) @fn.def))")
 local path_query = vim_ts.query.parse("fennel", "\n(local_form\n  (binding_pair\n    rhs: (list\n           call: (symbol) (#any-of? \"autoload\" \"require\")\n           item: (string) @import.path)))")
 local function get_current_root(bufnr, lang)
   local bufnr0 = (bufnr or 0)
@@ -15,24 +16,25 @@ local function get_current_root(bufnr, lang)
   local tree = parser:parse()[1]
   return tree:root()
 end
-local function search_targets(query, root_node, bufnr, last)
+local function search_targets(query, root_node, bufnr, last, first)
   local bufnr0 = (bufnr or 0)
   local last0 = (last or ( - 1))
-  local tbl_21_ = {}
-  local i_22_ = 0
-  for id, node in query:iter_captures(root_node, bufnr0, 0, last0) do
-    local val_23_ = conjure_ts["node->table"](node)
-    if (nil ~= val_23_) then
-      i_22_ = (i_22_ + 1)
-      tbl_21_[i_22_] = val_23_
+  local first0 = (first or 0)
+  local tbl_21_auto = {}
+  local i_22_auto = 0
+  for id, node in query:iter_captures(root_node, bufnr0, first0, last0) do
+    local val_23_auto = conjure_ts["node->table"](node)
+    if (nil ~= val_23_auto) then
+      i_22_auto = (i_22_auto + 1)
+      tbl_21_auto[i_22_auto] = val_23_auto
     else
     end
   end
-  return tbl_21_
+  return tbl_21_auto
 end
---[[ (search-targets def-query (get-current-root) 0 20) ]]
+--[[ (search-targets def-local-query (get-current-root) 0 20) ]]
 local function search_in_buffer(code_text, last_row, bufnr)
-  local curr_targets = search_targets(def_query, get_current_root(bufnr), bufnr, last_row)
+  local curr_targets = search_targets(def_local_query, get_current_root(bufnr), bufnr, last_row)
   local results
   local function _3_(node_t)
     return (code_text == node_t.content)
@@ -43,10 +45,10 @@ end
 local function search_ext_targets(query, root_node, bufnr, last)
   local last0 = (last or -1)
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-  local tbl_21_ = {}
-  local i_22_ = 0
+  local tbl_21_auto = {}
+  local i_22_auto = 0
   for id, node in query:iter_captures(root_node, bufnr, 0, last0) do
-    local val_23_
+    local val_23_auto
     do
       local range = conjure_ts.range(node)
       local start_row = core["get-in"](range, {"start", 1})
@@ -54,18 +56,18 @@ local function search_ext_targets(query, root_node, bufnr, last)
       local end_row = core["get-in"](range, {"end", 1})
       local end_col = core["get-in"](range, {"end", 2})
       local content = string.sub(core.get(lines, start_row), (1 + start_col), (1 + end_col))
-      val_23_ = {content = content, range = range}
+      val_23_auto = {content = content, range = range}
     end
-    if (nil ~= val_23_) then
-      i_22_ = (i_22_ + 1)
-      tbl_21_[i_22_] = val_23_
+    if (nil ~= val_23_auto) then
+      i_22_auto = (i_22_auto + 1)
+      tbl_21_auto[i_22_auto] = val_23_auto
     else
     end
   end
-  return tbl_21_
+  return tbl_21_auto
 end
 local function search_in_ext_buffer(code_text, last_row, bufnr)
-  local curr_targets = search_ext_targets(def_query, get_current_root(bufnr), bufnr, last_row)
+  local curr_targets = search_ext_targets(def_ext_query, get_current_root(bufnr), bufnr, last_row)
   local results
   local function _5_(node_t)
     return (code_text == node_t.content)
@@ -85,34 +87,34 @@ end
 local function resolve_fnl_module_path(modname)
   return package.searchpath(modname, config.default()["fennel-path"])
 end
-local function imported_modules(resolve, last_row)
+local function imported_modules(resolve, last_row, first_row)
   local root = get_current_root()
   local raw_mods
   do
-    local tbl_21_ = {}
-    local i_22_ = 0
-    for _, node_t in ipairs(search_targets(path_query, root, 0, last_row)) do
-      local val_23_ = rest_str(node_t.content)
-      if (nil ~= val_23_) then
-        i_22_ = (i_22_ + 1)
-        tbl_21_[i_22_] = val_23_
+    local tbl_21_auto = {}
+    local i_22_auto = 0
+    for _, node_t in ipairs(search_targets(path_query, root, 0, last_row, first_row)) do
+      local val_23_auto = rest_str(node_t.content)
+      if (nil ~= val_23_auto) then
+        i_22_auto = (i_22_auto + 1)
+        tbl_21_auto[i_22_auto] = val_23_auto
       else
       end
     end
-    raw_mods = tbl_21_
+    raw_mods = tbl_21_auto
   end
   notify.debug(("raw-mods: " .. core["pr-str"](raw_mods)))
-  local tbl_21_ = {}
-  local i_22_ = 0
+  local tbl_21_auto = {}
+  local i_22_auto = 0
   for _, m in ipairs(raw_mods) do
-    local val_23_ = resolve(m)
-    if (nil ~= val_23_) then
-      i_22_ = (i_22_ + 1)
-      tbl_21_[i_22_] = val_23_
+    local val_23_auto = resolve(m)
+    if (nil ~= val_23_auto) then
+      i_22_auto = (i_22_auto + 1)
+      tbl_21_auto[i_22_auto] = val_23_auto
     else
     end
   end
-  return tbl_21_
+  return tbl_21_auto
 end
 --[[ (icollect [id node_t (ipairs (search-targets path-query (get-current-root) 0 30))] (rest-str node_t.content)) (imported-modules resolve-fnl-module-path -1) ]]
 local function search_in_ext_file(code_text, file_path)
@@ -129,13 +131,21 @@ local function search_in_ext_file(code_text, file_path)
     return false
   end
 end
---[[ (local f "/Users/laurencechen/.local/share/nvim/plugged/nfnl/fnl/nfnl/notify.fnl") (local bufnr (vim.fn.bufadd f)) (vim.fn.bufload bufnr) (search-ext-targets def-query (get-current-root bufnr "fennel") bufnr) (search-in-ext-buffer "debug" -1 bufnr) (search-in-ext-file "debug" f) ]]
-local function remove_module_name(s)
-  local start_index, end_index = string.find(s, "%.")
+--[[ (local f "/Users/laurencechen/.local/share/nvim/plugged/nfnl/fnl/nfnl/notify.fnl") (local bufnr (vim.fn.bufadd f)) (vim.fn.bufload bufnr) (search-ext-targets def-local-query (get-current-root bufnr "fennel") bufnr) (search-in-ext-buffer "debug" -1 bufnr) (search-in-ext-file "debug" f) ]]
+local function fn_name(s)
+  local start_index, _ = string.find(s, "%.")
   if start_index then
     return string.sub(s, (1 + start_index))
   else
     return s
+  end
+end
+local function module_name(s)
+  local start_index, _ = string.find(s, "%.")
+  if start_index then
+    return string.sub(s, 1, (start_index - 1))
+  else
+    return nil
   end
 end
 local function reverse(xs)
@@ -146,36 +156,49 @@ local function reverse(xs)
   end
   return new_list
 end
+local function cross_jump(fn_text, fnl_imports)
+  notify.debug(("fnl-path: " .. config.default()["fennel-path"]))
+  notify.debug(("search symbol in the following fnl libs: " .. core["pr-str"](fnl_imports)))
+  local results = {}
+  for _, file_path in ipairs(fnl_imports) do
+    notify.debug(("search in file-path: " .. file_path .. " for fn-text " .. fn_text))
+    local r = search_in_ext_file(fn_text, file_path)
+    notify.debug(("get result " .. tostring(r) .. " from search"))
+    table.insert(results, r)
+  end
+  if not core.some(core.identity, results) then
+    return {result = "definition not found"}
+  else
+    return nil
+  end
+end
 local function search_and_jump(code_text, last_row)
   notify.debug(("code-text: " .. code_text))
-  local code_text0 = remove_module_name(code_text)
-  local results = search_in_buffer(code_text0, last_row, 0)
+  local results = search_in_buffer(code_text, last_row, 0)
+  local module_text = module_name(code_text)
+  local module_results = search_in_buffer(module_text, last_row, 0)
+  local fn_text = fn_name(code_text)
   local fnl_imports = imported_modules(resolve_fnl_module_path, last_row)
-  local r_fnl_imports = reverse(fnl_imports)
   if (#results > 0) then
     do
       local node = core.last(results)
       jump_to_range(node.range)
     end
     return results
-  elseif (#r_fnl_imports > 0) then
+  elseif (#module_results > 0) then
+    notify.debug("begin direct cross fnl module jump to certain module")
+    notify.debug(core.str(module_results))
+    local target = core.first(module_results)
+    local end_row = core["get-in"](target, {"range", "end", 1})
+    local fnl_imports0 = imported_modules(resolve_fnl_module_path, end_row, (end_row - 1))
+    return cross_jump(fn_text, fnl_imports0)
+  elseif (#fnl_imports > 0) then
     notify.debug("begin cross fnl module jump")
-    notify.debug(("fnl-path: " .. config.default()["fennel-path"]))
-    notify.debug(("search symbol in the following fnl libs: " .. core["pr-str"](r_fnl_imports)))
-    local results0 = {}
-    for _, file_path in ipairs(r_fnl_imports) do
-      local r = search_in_ext_file(code_text0, file_path)
-      notify.debug(("search in file-path: " .. file_path .. " for code-text " .. code_text0 .. " result " .. tostring(r)))
-      table.insert(results0, r)
-    end
-    if not core.some(core.identity, results0) then
-      return {result = "definition not found"}
-    else
-      return nil
-    end
+    local r_fnl_imports = reverse(fnl_imports)
+    return cross_jump(fn_text, r_fnl_imports)
   else
     return nil
   end
 end
 --[[ (search-and-jump "search-and-jump" 39) (search-and-jump "search-and-jump" 49) ]]
-return {["search-and-jump"] = search_and_jump, ["search-targets"] = search_targets, ["def-query"] = def_query, ["get-current-root"] = get_current_root}
+return {["search-and-jump"] = search_and_jump, ["search-targets"] = search_targets, ["get-current-root"] = get_current_root, ["def-local-query"] = def_local_query, ["def-ext-query"] = def_ext_query, ["imported-modules"] = imported_modules, ["resolve-fnl-module-path"] = resolve_fnl_module_path}

--- a/lua/conjure/client/fennel/def-str-util.lua
+++ b/lua/conjure/client/fennel/def-str-util.lua
@@ -48,7 +48,7 @@ local function search_and_jump(code_text, last_row)
   results = core.filter(_4_, curr_targets)
   if (#results > 0) then
     do
-      local node = core.first(results)
+      local node = core.last(results)
       local range = node.range
       vim.api.nvim_win_set_cursor(0, range.start)
     end

--- a/lua/conjure/client/fennel/def-str-util.lua
+++ b/lua/conjure/client/fennel/def-str-util.lua
@@ -1,0 +1,61 @@
+-- [nfnl] Compiled from fnl/conjure/client/fennel/def-str-util.fnl by https://github.com/Olical/nfnl, do not edit.
+local _local_1_ = require("conjure.nfnl.module")
+local autoload = _local_1_["autoload"]
+local core = autoload("conjure.nfnl.core")
+local conjure_ts = autoload("conjure.tree-sitter")
+local ts_utils = autoload("nvim-treesitter.ts_utils")
+local vim_ts = autoload("vim.treesitter")
+local def_query = vim_ts.query.parse("fennel", "\n(local_form\n (binding_pair\n   lhs: (symbol_binding) @local.def)) \n(fn_form\n  name: [(symbol) (multi_symbol)] @fn.def)")
+local function prt(t)
+  for k, v in pairs(t) do
+    if (type(v) ~= "table") then
+      print(k, v)
+    else
+      print(k)
+      prt(v)
+    end
+  end
+  return nil
+end
+local function get_current_root()
+  local bufnr = 0
+  local parser = vim_ts.get_parser(bufnr)
+  local tree = parser:parse()[1]
+  return tree:root()
+end
+local function search_targets(query, root_node, bufnr, last)
+  local bufnr0 = (bufnr or 0)
+  local last0 = (last or ( - 1))
+  local tbl_21_auto = {}
+  local i_22_auto = 0
+  for id, node in query:iter_captures(root_node, bufnr0, 0, last0) do
+    local val_23_auto = conjure_ts["node->table"](node)
+    if (nil ~= val_23_auto) then
+      i_22_auto = (i_22_auto + 1)
+      tbl_21_auto[i_22_auto] = val_23_auto
+    else
+    end
+  end
+  return tbl_21_auto
+end
+--[[ (search-targets def-query (get-current-root) 0 20) ]]
+local function search_and_jump(code_text, last_row)
+  local curr_targets = search_targets(def_query, get_current_root(), 0, last_row)
+  local results
+  local function _4_(node_t)
+    return (code_text == node_t.content)
+  end
+  results = core.filter(_4_, curr_targets)
+  if (#results > 0) then
+    do
+      local node = core.first(results)
+      local range = node.range
+      vim.api.nvim_win_set_cursor(0, range.start)
+    end
+    return results
+  else
+    return {result = "definition not found"}
+  end
+end
+--[[ (search-and-jump "search-and-jump" 39) (search-and-jump "search-and-jump" 49) ]]
+return {["search-and-jump"] = search_and_jump, ["search-targets"] = search_targets, ["def-query"] = def_query, ["get-current-root"] = get_current_root}

--- a/lua/conjure/client/fennel/def-str-util.lua
+++ b/lua/conjure/client/fennel/def-str-util.lua
@@ -22,17 +22,17 @@ end
 local function search_targets(query, root_node, bufnr, last)
   local bufnr0 = (bufnr or 0)
   local last0 = (last or ( - 1))
-  local tbl_21_ = {}
-  local i_22_ = 0
+  local tbl_21_auto = {}
+  local i_22_auto = 0
   for id, node in query:iter_captures(root_node, bufnr0, 0, last0) do
-    local val_23_ = conjure_ts["node->table"](node)
-    if (nil ~= val_23_) then
-      i_22_ = (i_22_ + 1)
-      tbl_21_[i_22_] = val_23_
+    local val_23_auto = conjure_ts["node->table"](node)
+    if (nil ~= val_23_auto) then
+      i_22_auto = (i_22_auto + 1)
+      tbl_21_auto[i_22_auto] = val_23_auto
     else
     end
   end
-  return tbl_21_
+  return tbl_21_auto
 end
 --[[ (search-targets def-query (get-current-root) 0 20) ]]
 local function search_in_buffer(code_text, last_row, bufnr)
@@ -47,10 +47,10 @@ end
 local function search_ext_targets(query, root_node, bufnr, last)
   local last0 = (last or -1)
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-  local tbl_21_ = {}
-  local i_22_ = 0
+  local tbl_21_auto = {}
+  local i_22_auto = 0
   for id, node in query:iter_captures(root_node, bufnr, 0, last0) do
-    local val_23_
+    local val_23_auto
     do
       local range = conjure_ts.range(node)
       local start_row = core["get-in"](range, {"start", 1})
@@ -58,15 +58,15 @@ local function search_ext_targets(query, root_node, bufnr, last)
       local end_row = core["get-in"](range, {"end", 1})
       local end_col = core["get-in"](range, {"end", 2})
       local content = string.sub(core.get(lines, start_row), (1 + start_col), (1 + end_col))
-      val_23_ = {content = content, range = range}
+      val_23_auto = {content = content, range = range}
     end
-    if (nil ~= val_23_) then
-      i_22_ = (i_22_ + 1)
-      tbl_21_[i_22_] = val_23_
+    if (nil ~= val_23_auto) then
+      i_22_auto = (i_22_auto + 1)
+      tbl_21_auto[i_22_auto] = val_23_auto
     else
     end
   end
-  return tbl_21_
+  return tbl_21_auto
 end
 local function search_in_ext_buffer(code_text, last_row, bufnr)
   local curr_targets = search_ext_targets(def_query, get_current_root(bufnr), bufnr, last_row)
@@ -93,29 +93,29 @@ local function imported_modules(resolve, last_row)
   local root = get_current_root()
   local raw_mods
   do
-    local tbl_21_ = {}
-    local i_22_ = 0
+    local tbl_21_auto = {}
+    local i_22_auto = 0
     for _, node_t in ipairs(search_targets(path_query, root, 0, last_row)) do
-      local val_23_ = rest_str(node_t.content)
-      if (nil ~= val_23_) then
-        i_22_ = (i_22_ + 1)
-        tbl_21_[i_22_] = val_23_
+      local val_23_auto = rest_str(node_t.content)
+      if (nil ~= val_23_auto) then
+        i_22_auto = (i_22_auto + 1)
+        tbl_21_auto[i_22_auto] = val_23_auto
       else
       end
     end
-    raw_mods = tbl_21_
+    raw_mods = tbl_21_auto
   end
-  local tbl_21_ = {}
-  local i_22_ = 0
+  local tbl_21_auto = {}
+  local i_22_auto = 0
   for _, m in ipairs(raw_mods) do
-    local val_23_ = resolve(m)
-    if (nil ~= val_23_) then
-      i_22_ = (i_22_ + 1)
-      tbl_21_[i_22_] = val_23_
+    local val_23_auto = resolve(m)
+    if (nil ~= val_23_auto) then
+      i_22_auto = (i_22_auto + 1)
+      tbl_21_auto[i_22_auto] = val_23_auto
     else
     end
   end
-  return tbl_21_
+  return tbl_21_auto
 end
 --[[ (icollect [id node_t (ipairs (search-targets path-query (get-current-root) 0 30))] (rest-str node_t.content)) (imported-modules resolve-fnl-module-path -1) ]]
 local function search_in_file(code_text, file_path)

--- a/lua/conjure/client/fennel/def-str-util.lua
+++ b/lua/conjure/client/fennel/def-str-util.lua
@@ -10,7 +10,6 @@ local notify = autoload("nfnl.notify")
 local config = autoload("nfnl.config")
 local _local_2_ = autoload("nfnl.nvim")
 local get_buf_content_as_string = _local_2_["get-buf-content-as-string"]
---[[ (fennel.view {:a 15 :b 16}) (notify.info "hello") ]]
 local def_query = vim_ts.query.parse("fennel", "\n(local_form\n (binding_pair\n   lhs: (symbol_binding) @local.def)) \n(fn_form\n  name: [(symbol) (multi_symbol)] @fn.def)")
 local path_query = vim_ts.query.parse("fennel", "\n(local_form\n  (binding_pair\n    rhs: (list\n           call: (symbol) (#any-of? \"autoload\" \"require\")\n           item: (string) @import.path)))")
 local function get_current_root(bufnr, lang)
@@ -142,7 +141,6 @@ local function remove_module_name(s)
   end
 end
 local function search_and_jump(code_text, last_row)
-  print(code_text, last_row)
   local results = search_in_buffer(code_text, last_row, 0)
   local fnl_imports = imported_modules(resolve_fnl_module_path, last_row)
   if (#results > 0) then
@@ -152,7 +150,6 @@ local function search_and_jump(code_text, last_row)
     end
     return results
   elseif (#fnl_imports > 0) then
-    core.pr(#fnl_imports)
     for _, file_path in ipairs(fnl_imports) do
       local code_text0 = remove_module_name(code_text)
       local r = search_in_file(code_text0, file_path)

--- a/lua/conjure/client/fennel/def-str-util.lua
+++ b/lua/conjure/client/fennel/def-str-util.lua
@@ -3,13 +3,8 @@ local _local_1_ = require("conjure.nfnl.module")
 local autoload = _local_1_["autoload"]
 local core = autoload("conjure.nfnl.core")
 local conjure_ts = autoload("conjure.tree-sitter")
-local ts_utils = autoload("nvim-treesitter.ts_utils")
 local vim_ts = autoload("vim.treesitter")
-local fennel = autoload("nfnl.fennel")
-local notify = autoload("nfnl.notify")
-local config = autoload("nfnl.config")
-local _local_2_ = autoload("nfnl.nvim")
-local get_buf_content_as_string = _local_2_["get-buf-content-as-string"]
+local config = autoload("conjure.nfnl.config")
 local def_query = vim_ts.query.parse("fennel", "\n(local_form\n (binding_pair\n   lhs: (symbol_binding) @local.def)) \n(fn_form\n  name: [(symbol) (multi_symbol)] @fn.def)")
 local path_query = vim_ts.query.parse("fennel", "\n(local_form\n  (binding_pair\n    rhs: (list\n           call: (symbol) (#any-of? \"autoload\" \"require\")\n           item: (string) @import.path)))")
 local function get_current_root(bufnr, lang)
@@ -38,10 +33,10 @@ end
 local function search_in_buffer(code_text, last_row, bufnr)
   local curr_targets = search_targets(def_query, get_current_root(bufnr), bufnr, last_row)
   local results
-  local function _4_(node_t)
+  local function _3_(node_t)
     return (code_text == node_t.content)
   end
-  results = core.filter(_4_, curr_targets)
+  results = core.filter(_3_, curr_targets)
   return results
 end
 local function search_ext_targets(query, root_node, bufnr, last)
@@ -71,10 +66,10 @@ end
 local function search_in_ext_buffer(code_text, last_row, bufnr)
   local curr_targets = search_ext_targets(def_query, get_current_root(bufnr), bufnr, last_row)
   local results
-  local function _6_(node_t)
+  local function _5_(node_t)
     return (code_text == node_t.content)
   end
-  results = core.filter(_6_, curr_targets)
+  results = core.filter(_5_, curr_targets)
   return results
 end
 local function jump_to_range(range)

--- a/lua/conjure/client/fennel/def-str-util.lua
+++ b/lua/conjure/client/fennel/def-str-util.lua
@@ -6,9 +6,10 @@ local conjure_ts = autoload("conjure.tree-sitter")
 local vim_ts = autoload("vim.treesitter")
 local config = autoload("conjure.nfnl.config")
 local notify = autoload("conjure.nfnl.notify")
-local def_local_query = vim_ts.query.parse("fennel", "\n(local_form\n (binding_pair\n   lhs: (symbol_binding) @local.def)) \n(fn_form\n  name: [(symbol) (multi_symbol)] @local.fn.def)")
-local def_ext_query = vim_ts.query.parse("fennel", "\n(local_form\n (binding_pair\n   lhs: (symbol_binding) @local.def)) \n(fn_form\n  name: (symbol) @fn.def)\n(fn_form\n  name: (multi_symbol\n    member: (symbol_fragment) @fn.def))")
-local path_query = vim_ts.query.parse("fennel", "\n(local_form\n  (binding_pair\n    rhs: (list\n           call: (symbol) (#any-of? \"autoload\" \"require\")\n           item: (string) @import.path)))")
+local res = autoload("conjure.resources")
+local def_local_query = vim_ts.query.parse("fennel", res["get-resource-contents"]("queries/fennel/local-def.scm"))
+local def_ext_query = vim_ts.query.parse("fennel", res["get-resource-contents"]("queries/fennel/ext-def.scm"))
+local path_query = vim_ts.query.parse("fennel", res["get-resource-contents"]("queries/fennel/import-path.scm"))
 local function get_current_root(bufnr, lang)
   local bufnr0 = (bufnr or 0)
   local lang0 = (lang or "fennel")
@@ -201,4 +202,4 @@ local function search_and_jump(code_text, last_row)
   end
 end
 --[[ (search-and-jump "search-and-jump" 39) (search-and-jump "search-and-jump" 49) ]]
-return {["search-and-jump"] = search_and_jump, ["search-targets"] = search_targets, ["get-current-root"] = get_current_root, ["def-local-query"] = def_local_query, ["def-ext-query"] = def_ext_query, ["imported-modules"] = imported_modules, ["resolve-fnl-module-path"] = resolve_fnl_module_path}
+return {["search-and-jump"] = search_and_jump, ["search-targets"] = search_targets, ["get-current-root"] = get_current_root, ["def-local-query"] = def_local_query, ["def-ext-query"] = def_ext_query, ["path-query"] = path_query, ["imported-modules"] = imported_modules, ["resolve-fnl-module-path"] = resolve_fnl_module_path}

--- a/lua/conjure/client/fennel/def-str-util.lua
+++ b/lua/conjure/client/fennel/def-str-util.lua
@@ -118,7 +118,7 @@ local function imported_modules(resolve, last_row)
   return tbl_21_auto
 end
 --[[ (icollect [id node_t (ipairs (search-targets path-query (get-current-root) 0 30))] (rest-str node_t.content)) (imported-modules resolve-fnl-module-path -1) ]]
-local function search_in_file(code_text, file_path)
+local function search_in_ext_file(code_text, file_path)
   local bufnr = vim.fn.bufadd(file_path)
   vim.fn.bufload(bufnr)
   local cross_results = search_in_ext_buffer(code_text, -1, bufnr)
@@ -131,7 +131,7 @@ local function search_in_file(code_text, file_path)
   end
   return vim.api.nvim_buf_delete(bufnr, {})
 end
---[[ (local f "/Users/laurencechen/.local/share/nvim/plugged/nfnl/fnl/nfnl/notify.fnl") (local bufnr (vim.fn.bufadd f)) (vim.fn.bufload bufnr) (search-ext-targets def-query (get-current-root bufnr "fennel") bufnr) (search-in-ext-buffer "debug" -1 bufnr) (search-in-file "debug" f) ]]
+--[[ (local f "/Users/laurencechen/.local/share/nvim/plugged/nfnl/fnl/nfnl/notify.fnl") (local bufnr (vim.fn.bufadd f)) (vim.fn.bufload bufnr) (search-ext-targets def-query (get-current-root bufnr "fennel") bufnr) (search-in-ext-buffer "debug" -1 bufnr) (search-in-ext-file "debug" f) ]]
 local function remove_module_name(s)
   local start_index, end_index = string.find(s, "%.")
   if start_index then
@@ -152,7 +152,7 @@ local function search_and_jump(code_text, last_row)
   elseif (#fnl_imports > 0) then
     for _, file_path in ipairs(fnl_imports) do
       local code_text0 = remove_module_name(code_text)
-      local r = search_in_file(code_text0, file_path)
+      local r = search_in_ext_file(code_text0, file_path)
       if r then
         return r
       else

--- a/lua/conjure/client/fennel/def-str-util.lua
+++ b/lua/conjure/client/fennel/def-str-util.lua
@@ -18,17 +18,17 @@ end
 local function search_targets(query, root_node, bufnr, last)
   local bufnr0 = (bufnr or 0)
   local last0 = (last or ( - 1))
-  local tbl_21_auto = {}
-  local i_22_auto = 0
+  local tbl_21_ = {}
+  local i_22_ = 0
   for id, node in query:iter_captures(root_node, bufnr0, 0, last0) do
-    local val_23_auto = conjure_ts["node->table"](node)
-    if (nil ~= val_23_auto) then
-      i_22_auto = (i_22_auto + 1)
-      tbl_21_auto[i_22_auto] = val_23_auto
+    local val_23_ = conjure_ts["node->table"](node)
+    if (nil ~= val_23_) then
+      i_22_ = (i_22_ + 1)
+      tbl_21_[i_22_] = val_23_
     else
     end
   end
-  return tbl_21_auto
+  return tbl_21_
 end
 --[[ (search-targets def-query (get-current-root) 0 20) ]]
 local function search_in_buffer(code_text, last_row, bufnr)
@@ -43,10 +43,10 @@ end
 local function search_ext_targets(query, root_node, bufnr, last)
   local last0 = (last or -1)
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-  local tbl_21_auto = {}
-  local i_22_auto = 0
+  local tbl_21_ = {}
+  local i_22_ = 0
   for id, node in query:iter_captures(root_node, bufnr, 0, last0) do
-    local val_23_auto
+    local val_23_
     do
       local range = conjure_ts.range(node)
       local start_row = core["get-in"](range, {"start", 1})
@@ -54,15 +54,15 @@ local function search_ext_targets(query, root_node, bufnr, last)
       local end_row = core["get-in"](range, {"end", 1})
       local end_col = core["get-in"](range, {"end", 2})
       local content = string.sub(core.get(lines, start_row), (1 + start_col), (1 + end_col))
-      val_23_auto = {content = content, range = range}
+      val_23_ = {content = content, range = range}
     end
-    if (nil ~= val_23_auto) then
-      i_22_auto = (i_22_auto + 1)
-      tbl_21_auto[i_22_auto] = val_23_auto
+    if (nil ~= val_23_) then
+      i_22_ = (i_22_ + 1)
+      tbl_21_[i_22_] = val_23_
     else
     end
   end
-  return tbl_21_auto
+  return tbl_21_
 end
 local function search_in_ext_buffer(code_text, last_row, bufnr)
   local curr_targets = search_ext_targets(def_query, get_current_root(bufnr), bufnr, last_row)
@@ -89,30 +89,30 @@ local function imported_modules(resolve, last_row)
   local root = get_current_root()
   local raw_mods
   do
-    local tbl_21_auto = {}
-    local i_22_auto = 0
+    local tbl_21_ = {}
+    local i_22_ = 0
     for _, node_t in ipairs(search_targets(path_query, root, 0, last_row)) do
-      local val_23_auto = rest_str(node_t.content)
-      if (nil ~= val_23_auto) then
-        i_22_auto = (i_22_auto + 1)
-        tbl_21_auto[i_22_auto] = val_23_auto
+      local val_23_ = rest_str(node_t.content)
+      if (nil ~= val_23_) then
+        i_22_ = (i_22_ + 1)
+        tbl_21_[i_22_] = val_23_
       else
       end
     end
-    raw_mods = tbl_21_auto
+    raw_mods = tbl_21_
   end
   notify.debug(("raw-mods: " .. core["pr-str"](raw_mods)))
-  local tbl_21_auto = {}
-  local i_22_auto = 0
+  local tbl_21_ = {}
+  local i_22_ = 0
   for _, m in ipairs(raw_mods) do
-    local val_23_auto = resolve(m)
-    if (nil ~= val_23_auto) then
-      i_22_auto = (i_22_auto + 1)
-      tbl_21_auto[i_22_auto] = val_23_auto
+    local val_23_ = resolve(m)
+    if (nil ~= val_23_) then
+      i_22_ = (i_22_ + 1)
+      tbl_21_[i_22_] = val_23_
     else
     end
   end
-  return tbl_21_auto
+  return tbl_21_
 end
 --[[ (icollect [id node_t (ipairs (search-targets path-query (get-current-root) 0 30))] (rest-str node_t.content)) (imported-modules resolve-fnl-module-path -1) ]]
 local function search_in_ext_file(code_text, file_path)
@@ -137,22 +137,31 @@ local function remove_module_name(s)
     return s
   end
 end
+local function reverse(xs)
+  local new_list = {}
+  local n = #xs
+  for i = n, 1, -1 do
+    table.insert(new_list, xs[i])
+  end
+  return new_list
+end
 local function search_and_jump(code_text, last_row)
   notify.debug(("code-text: " .. code_text))
   local code_text0 = remove_module_name(code_text)
   local results = search_in_buffer(code_text0, last_row, 0)
   local fnl_imports = imported_modules(resolve_fnl_module_path, last_row)
+  local r_fnl_imports = reverse(fnl_imports)
   if (#results > 0) then
     do
       local node = core.last(results)
       jump_to_range(node.range)
     end
     return results
-  elseif (#fnl_imports > 0) then
+  elseif (#r_fnl_imports > 0) then
     notify.debug("begin cross fnl module jump")
     notify.debug(("fnl-path: " .. config.default()["fennel-path"]))
-    notify.debug(("search symbol in the following fnl libs: " .. core["pr-str"](fnl_imports)))
-    for _, file_path in ipairs(fnl_imports) do
+    notify.debug(("search symbol in the following fnl libs: " .. core["pr-str"](r_fnl_imports)))
+    for _, file_path in ipairs(r_fnl_imports) do
       local r = search_in_ext_file(code_text0, file_path)
       notify.debug(("search in file-path: " .. file_path .. " for code-text " .. code_text0))
       if r then

--- a/lua/conjure/client/fennel/nfnl.lua
+++ b/lua/conjure/client/fennel/nfnl.lua
@@ -1,4 +1,4 @@
--- [nfnl] fnl/conjure/client/fennel/nfnl.fnl
+-- [nfnl] Compiled from fnl/conjure/client/fennel/nfnl.fnl by https://github.com/Olical/nfnl, do not edit.
 local _local_1_ = require("conjure.nfnl.module")
 local autoload = _local_1_["autoload"]
 local define = _local_1_["define"]
@@ -12,6 +12,7 @@ local fennel = autoload("conjure.nfnl.fennel")
 local str = autoload("conjure.nfnl.string")
 local repl = autoload("conjure.nfnl.repl")
 local fs = autoload("conjure.nfnl.fs")
+local def_str_util = autoload("conjure.client.fennel.def-str-util")
 local M = define("conjure.client.fennel.nfnl", {["comment-node?"] = ts["lisp-comment-node?"], ["buf-suffix"] = ".fnl", ["comment-prefix"] = "; "})
 M["form-node?"] = function(node)
   return ts["node-surrounded-by-form-pair-chars?"](node, {{"#(", ")"}})
@@ -105,4 +106,12 @@ M["doc-str"] = function(opts)
   core.assoc(opts, "code", (",doc " .. opts.code))
   return M["eval-str"](opts)
 end
+M["def-str"] = function(opts)
+  if ts["enabled?"]() then
+    return def_str_util["search-and-jump"](opts.code, opts.range.start[1])
+  else
+    return log.append({"jump to def is not supported because treesitter is not enabled or installed"})
+  end
+end
+--[[ (M.eval-file "dafa") (def-str-util.search-and-jump "M.eval-file" 99) (def-str-util.search-targets def-str-util.def-query (def-str-util.get-current-root) 0 99) ]]
 return M

--- a/lua/conjure/client/fennel/nfnl.lua
+++ b/lua/conjure/client/fennel/nfnl.lua
@@ -113,5 +113,4 @@ M["def-str"] = function(opts)
     return log.append({"jump to def is not supported because treesitter is not enabled or installed"})
   end
 end
---[[ (M.eval-file "dafa") (def-str-util.search-and-jump "M.eval-file" 99) (def-str-util.search-targets def-str-util.def-query (def-str-util.get-current-root) 0 99) ]]
 return M

--- a/res/queries/fennel/ext-def.scm
+++ b/res/queries/fennel/ext-def.scm
@@ -1,0 +1,8 @@
+(local_form
+ (binding_pair
+   lhs: (symbol_binding) @local.def)) 
+(fn_form
+  name: (symbol) @fn.def)
+(fn_form
+  name: (multi_symbol
+    member: (symbol_fragment) @fn.def))

--- a/res/queries/fennel/import-path.scm
+++ b/res/queries/fennel/import-path.scm
@@ -1,0 +1,5 @@
+(local_form
+  (binding_pair
+    rhs: (list
+           call: (symbol) (#any-of? "autoload" "require")
+           item: (string) @import.path)))

--- a/res/queries/fennel/local-def.scm
+++ b/res/queries/fennel/local-def.scm
@@ -1,0 +1,5 @@
+(local_form
+ (binding_pair
+   lhs: (symbol_binding) @local.def)) 
+(fn_form
+  name: [(symbol) (multi_symbol)] @local.fn.def)


### PR DESCRIPTION
# Rational 

Although **jump to def** is already implemented by [fennel LSP solution](https://git.sr.ht/~xerool/fennel-ls), for people who want only to get a quick understanding on Fennel and do not bother to config LSP, it is still helpful for them to have an **out-of-box jump of def**. (Well, not 100% out-of-box, because it depends on treesitter.)

## Feature implemented
- [x] jump to def at local file
- [x] cross file jump for Fennel module (not including Lua module.)

## How to verify 

* Setup:  add the following code at the end of `fnl/conjure/client/fennel/nfnl.fnl `

```
(comment ;; testing code for def-str
  (M.eval-file :dafa)
  (def-str-util.search-and-jump :M.eval-file 99)
  (def-str-util.search-targets def-str-util.def-query
    (def-str-util.get-current-root)
    0
    99))
```

* Test
  1. Evaluate the **last two expressions** to have an idea of how the APIs work. The first expression `(M.eval-file :dafa)` is not meant for evaluation.
  2. Move cursor onto `M.eval-file`, and the press `<localleader> gd`
  3. Move cursor onto `def-str-util.search-and-jump`, and the press `<localleader> gd`
