### PR TITLE
JS: Fix export bug, support multiple type imports, and ensure type import semicolon consistency

### DIFF
--- a/dev/typescript/moped.ts
+++ b/dev/typescript/moped.ts
@@ -5,3 +5,6 @@ export interface IMoped {
   countWheels: () => number;
   getEngineDisplacement: () => number;
 }
+
+export type ConvertOptions = string;
+export type OptimizationOptions = number;

--- a/dev/typescript/sandbox.ts
+++ b/dev/typescript/sandbox.ts
@@ -72,7 +72,7 @@ import { minus } from "../javascript/math.js";
 
 minus(1, 2);
 
-import type { IMoped } from "./moped.ts";
+import type { IMoped } from "./moped.ts"
 
 class Moped implements IMoped {
   wheels: number
@@ -324,3 +324,13 @@ for (let user of users) {
 }
 
 process.stderr.write("error! some error occurred");
+
+import {
+  type ConvertOptions as CrateConvertOptions,
+  type OptimizationOptions,
+} from "./moped";
+
+export const expFn = () => "export fn";
+expFn()
+export function funFun() { return "export function Fun" }
+export { }

--- a/fnl/conjure/client/javascript/import-replacer.fnl
+++ b/fnl/conjure/client/javascript/import-replacer.fnl
@@ -17,11 +17,13 @@
 
 (fn is-type-import? [node code]
   (let [first-child (node:child 0)
-        second-child (node:child 1)]
-    (and first-child
+        second-child (node:child 1)
+        contains-type (string.find (tsc.get-text second-child code) "type")]
+    (or (and first-child
          (= (tsc.get-text first-child code) "import")
          second-child
-         (= (tsc.get-text second-child code) "type"))))
+         (= (tsc.get-text second-child code) "type"))
+        contains-type)))
 
 (fn clean-named-imports [node code]
   (let [text (tsc.get-text node code)]
@@ -34,7 +36,8 @@
   (if (and source.resolved-path source.text)
       (-> (tsc.get-text node code)
           (string.gsub (vim.pesc source.text)
-                       (string.format "\"%s\"" source.resolved-path)))
+                       (string.format "\"%s\"" source.resolved-path))
+          (.. ";"))
       (tsc.get-text node code)))
 
 (fn transform-plain-import [source]

--- a/fnl/conjure/client/javascript/stdio.fnl
+++ b/fnl/conjure/client/javascript/stdio.fnl
@@ -134,7 +134,7 @@
 
 ;; To get rid of the "Uncaught SyntaxError: Unexpected token 'export'", 
 ;; the REPL silently evaluates the following expression: 
-(set M.initialise-repl-code "1+1")
+(set M.initialise-repl-code "")
 
 (fn repl-command-for-filetype []
   (if
@@ -162,6 +162,7 @@
            :on-success
            (fn []
              (display-repl-status :started)
+             (let [repl (state :repl)] (repl.send "1+1;"))
              (with-repl-or-warn
                  (fn [repl]
                    (repl.send

--- a/fnl/conjure/client/javascript/transformers.fnl
+++ b/fnl/conjure/client/javascript/transformers.fnl
@@ -82,6 +82,17 @@
 (set node-handlers.call_expression
      (ir.call-expression node-handlers.default))
 
+(set node-handlers.export_statement
+     (fn [node code]
+       (let [child (node:child 1)]
+         (case (child:type)
+           (where (or "interface_declaration" "class_declaration")) 
+           (node-handlers.default node code)
+
+           "export_clause" ""
+
+           _ (node-handlers.default child code)))))
+
 (each [_ t (pairs
              [:expression_statement
               :variable_declaration
@@ -90,11 +101,11 @@
               :break_statement
               :continue_statement
               :debugger_statement
-              :export_statement
               :class_declaration
               :field_definition
               :public_field_definition
-              :function_declaration])]
+              :function_declaration ])]
+
   (set (. node-handlers t) handle-statement))
 
 (fn M.transform [s]

--- a/lua/conjure/client/javascript/import-replacer.lua
+++ b/lua/conjure/client/javascript/import-replacer.lua
@@ -15,7 +15,8 @@ end
 local function is_type_import_3f(node, code)
   local first_child = node:child(0)
   local second_child = node:child(1)
-  return (first_child and (tsc["get-text"](first_child, code) == "import") and second_child and (tsc["get-text"](second_child, code) == "type"))
+  local contains_type = string.find(tsc["get-text"](second_child, code), "type")
+  return ((first_child and (tsc["get-text"](first_child, code) == "import") and second_child and (tsc["get-text"](second_child, code) == "type")) or contains_type)
 end
 local function clean_named_imports(node, code)
   local text0 = tsc["get-text"](node, code)
@@ -23,7 +24,7 @@ local function clean_named_imports(node, code)
 end
 local function transform_type_import(node, code, source)
   if (source["resolved-path"] and source.text) then
-    return string.gsub(tsc["get-text"](node, code), vim.pesc(source.text), string.format("\"%s\"", source["resolved-path"]))
+    return (string.gsub(tsc["get-text"](node, code), vim.pesc(source.text), string.format("\"%s\"", source["resolved-path"])) .. ";")
   else
     return tsc["get-text"](node, code)
   end

--- a/lua/conjure/client/javascript/stdio.lua
+++ b/lua/conjure/client/javascript/stdio.lua
@@ -136,7 +136,7 @@ M.stop = function()
     return nil
   end
 end
-M["initialise-repl-code"] = "1+1"
+M["initialise-repl-code"] = ""
 local function repl_command_for_filetype()
   if ("javascript" == vim.bo.filetype) then
     return cfg({"javascript_cmd"})
@@ -152,6 +152,10 @@ M.start = function()
   else
     local function _18_()
       display_repl_status("started")
+      do
+        local repl = state("repl")
+        repl.send("1+1;")
+      end
       local function _19_(repl)
         local function _20_(msgs)
           return display_result(M["format-msg"](M.unbatch(msgs)))

--- a/lua/conjure/client/javascript/transformers.lua
+++ b/lua/conjure/client/javascript/transformers.lua
@@ -109,7 +109,20 @@ end
 node_handlers.member_expression = _14_
 node_handlers.import_statement = ir["import-statement"](handle_statement)
 node_handlers.call_expression = ir["call-expression"](node_handlers.default)
-for _, t in pairs({"expression_statement", "variable_declaration", "return_statement", "throw_statement", "break_statement", "continue_statement", "debugger_statement", "export_statement", "class_declaration", "field_definition", "public_field_definition", "function_declaration"}) do
+local function _16_(node, code)
+  local child = node:child(1)
+  local _17_ = child:type()
+  if ((_17_ == "interface_declaration") or (_17_ == "class_declaration")) then
+    return node_handlers.default(node, code)
+  elseif (_17_ == "export_clause") then
+    return ""
+  else
+    local _ = _17_
+    return node_handlers.default(child, code)
+  end
+end
+node_handlers.export_statement = _16_
+for _, t in pairs({"expression_statement", "variable_declaration", "return_statement", "throw_statement", "break_statement", "continue_statement", "debugger_statement", "class_declaration", "field_definition", "public_field_definition", "function_declaration"}) do
   node_handlers[t] = handle_statement
 end
 M.transform = function(s)


### PR DESCRIPTION
This pull request addresses several improvements and bug fixes in the JavaScript/TypeScript export and import handling:

- Fixes an export bug affecting module exports.
- Supports multiple type imports in TypeScript, improving compatibility with various import statements.(https://github.com/Olical/conjure/pull/698#issuecomment-3362782937)
- Ensures consistent use of semicolons for type imports, resolving potential syntax issues.

These changes should make the export and import logic more robust and help prevent errors when dealing with complex TypeScript modules.