### PR TITLE
Improve Lua client and scripts/test

### DIFF
--- a/fnl/conjure/client/lua/neovim.fnl
+++ b/fnl/conjure/client/lua/neovim.fnl
@@ -1,24 +1,32 @@
-(local {: autoload} (require :conjure.nfnl.module))
-(local a (autoload :conjure.aniseed.core))
-(local str (autoload :conjure.aniseed.string))
+(local {: autoload : define} (require :conjure.nfnl.module))
+(local core (autoload :conjure.nfnl.core))
+(local str (autoload :conjure.nfnl.string))
 (local config (autoload :conjure.config))
 (local mapping (autoload :conjure.mapping))
 (local log (autoload :conjure.log))
 (local fs (autoload :conjure.fs))
 (local extract (autoload :conjure.extract))
 
-(local buf-suffix ".lua")
-(local comment-prefix "-- ")
+(local M
+  (define :conjure.client.lua.neovim
+    {:buf-suffix ".lua"
+    :comment-prefix "-- "}))
+
+; moved the set forms into the define like client.fennel.nfnl does.
+; (set M.buf-suffix ".lua")
+; (set M.comment-prefix "-- ")
 
 ; These types of nodes are roughly equivalent to Lisp forms. This should make
 ; it more intuitive when using <localleader>ee to evaluate the "current form".
-(fn form-node? [node]
+(fn M.form-node? [node]
   (or (= "function_call" (node:type))
       (= "function_definition" (node:type))
       (= "function_declaration" (node:type))
       (= "local_declaration" (node:type))
       (= "variable_declaration" (node:type))
-      (= "if_statement" (node:type))))
+      (= "if_statement" (node:type))
+      (= "for_statement" (node:type))
+      (= "assignment_statement" (node:type))))
 
 (config.merge
   {:client
@@ -35,37 +43,39 @@
                   :reset_all_envs "ra"}}}}}))
 
 (local cfg (config.get-in-fn [:client :lua :neovim]))
-(local repls {})
+(set M.repls (or M.repls {}))
 
 ;; Two following functions are modified client/fennel/aniseed.fnl
-(fn reset-env [filename]
+(fn M.reset-env [filename]
   (let [filename (or filename (fs.localise-path (extract.file-path)))]
-    (tset repls filename nil)
-    (log.append [(.. comment-prefix "Reset environment for " filename)] {:break? true})))
+    (tset M.repls filename nil)
+    (log.append [(.. M.comment-prefix "Reset environment for " filename)] {:break? true})))
 
-(fn reset-all-envs []
-  (a.run!
+(fn M.reset-all-envs []
+  (core.run!
     (fn [filename]
-      (tset repls filename nil))
-    (a.keys repls))
-  (log.append [(.. comment-prefix "Reset all environments")] {:break? true}))
+      (tset M.repls filename nil))
+    (core.keys M.repls))
+  (log.append [(.. M.comment-prefix "Reset all environments")] {:break? true}))
 
-(fn on-filetype []
+(fn M.on-filetype []
   (mapping.buf
     :LuaResetEnv (cfg [:mapping :reset_env])
-    #(reset-env))
+    #(M.reset-env)
+    {:desc "Reset the Lua REPL environment"})
 
   (mapping.buf
     :LuaResetAllEnvs (cfg [:mapping :reset_all_envs])
-    #(reset-all-envs)))
+    #(M.reset-all-envs)
+    {:desc "Reset all Lua REPL environments"}))
 
 (fn display [out ret err]
   (let [outs (->> (str.split (or out "") "\n")
-                  (a.filter #(~= "" $1))
-                  (a.map #(.. comment-prefix "(out) " $1)))
+                  (core.filter #(~= "" $1))
+                  (core.map #(.. M.comment-prefix "(out) " $1)))
         errs (->> (str.split (or err "") "\n")
-                  (a.filter #(~= "" $1))
-                  (a.map #(.. comment-prefix "(err) " $1)))]
+                  (core.filter #(~= "" $1))
+                  (core.map #(.. M.comment-prefix "(err) " $1)))]
     (log.append outs)
     (log.append errs)
     (log.append (str.split (.. "res = " (vim.inspect ret)) "\n"))))
@@ -76,7 +86,7 @@
     (let [(f e) (load (.. "return (" opts.code "\n)"))]
       (if f (values f e) (load opts.code)))))
 
-(fn default-env []
+(fn M.default-env []
   (let [base (setmetatable {:REDIRECTED-OUTPUT ""
                             :io (setmetatable {} {:__index _G.io})}
                            {:__index _G})
@@ -97,17 +107,17 @@
     base))
 
 (fn pcall-default [f]
-  (let [env (default-env)]
+  (let [env (M.default-env)]
     (setfenv f env)
     (let [(status ret) (pcall f)]
       (values status ret env.REDIRECTED-OUTPUT))))
 
 ;; this function is ugly due to the imperative interface of debug.getlocal
 (fn pcall-persistent-debug [file f]
-  (tset repls file (or (. repls file) {}))
-  (tset (. repls file) :env (or (. repls file :env) (default-env)))
-  (tset (. repls file :env) :REDIRECTED-OUTPUT "") ;; Clear last output
-  (setfenv f (. repls file :env))
+  (tset M.repls file (or (. M.repls file) {}))
+  (tset (. M.repls file) :env (or (. M.repls file :env) (M.default-env)))
+  (tset (. M.repls file :env) :REDIRECTED-OUTPUT "") ;; Clear last output
+  (setfenv f (. M.repls file :env))
   (let [collect-env
         (fn [_ _]
           (debug.sethook)
@@ -118,11 +128,11 @@
             (set (n v) (debug.getlocal 2 i))
             (if n
               (do
-                (tset (. repls file :env) n v)
+                (tset (. M.repls file :env) n v)
                 (set i (+ i 1))))))]
     (debug.sethook collect-env :r)
     (let [(status ret) (pcall f)]
-      (values status ret (. repls file :env :REDIRECTED-OUTPUT)))))
+      (values status ret (. M.repls file :env :REDIRECTED-OUTPUT)))))
 
 (fn lua-eval [opts]
   (let [(f e) (lua-compile opts)]
@@ -136,25 +146,17 @@
           (values out nil (.. "Execution error: " ret))))
       (values "" nil (.. "Compilation error: " e)))))
 
-(fn eval-str [opts]
+(fn M.eval-str [opts]
   (let [(out ret err) (lua-eval opts)]
     (display out ret err)
     (when opts.on-result
       (opts.on-result (vim.inspect ret)))))
 
-(fn eval-file [opts]
-  (reset-env opts.file-path)
+(fn M.eval-file [opts]
+  (M.reset-env opts.file-path)
   (let [(out ret err) (lua-eval opts)]
     (display out ret err)
     (when opts.on-result
       (opts.on-result (vim.inspect ret)))))
 
-{: buf-suffix
- : comment-prefix
- : form-node?
- : reset-env
- : reset-all-envs
- : on-filetype
- : default-env
- : eval-str
- : eval-file}
+M

--- a/scripts/test
+++ b/scripts/test
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 XDG_CONFIG_HOME=$(pwd)/.test
-export XDG_CONFIG_HOME
+XDG_DATA_HOME=$(pwd)/.test/data
+XDG_STATE_HOME=$(pwd)/.test/state
+export XDG_CONFIG_HOME XDG_DATA_HOME XDG_STATE_HOME
 
 nvim --headless -c 'PlenaryBustedDirectory lua/conjure-spec'


### PR DESCRIPTION
Improvements:
- Change the Lua client to the nfnl module style.
- Enable `<localleader>ee` of `assignments` and `for` statements by the Lua client.
- Add `XDG_DATA_HOME` and `XDG_STATE_HOME` environment variables to `scripts/test` to isolate the test environment from the default nvim environment.