### PR TITLE
fix(common-lisp): make doc_word working for symbol which has package

### DIFF
--- a/fnl/conjure/tree-sitter.fnl
+++ b/fnl/conjure/tree-sitter.fnl
@@ -90,6 +90,7 @@
 (fn sym? [node]
   (when node
     (or (string.find (node:type) :sym)
+        (= (node:type) :package_lit) ;; just for common lisp
         (client.optional-call :symbol-node? node))))
 
 (fn get-leaf [node]

--- a/lua/conjure/tree-sitter.lua
+++ b/lua/conjure/tree-sitter.lua
@@ -89,7 +89,7 @@ local function leaf_3f(node)
 end
 local function sym_3f(node)
   if node then
-    return (string.find(node:type(), "sym") or client["optional-call"]("symbol-node?", node))
+    return (string.find(node:type(), "sym") or node:type() == "package_lit" or client["optional-call"]("symbol-node?", node))
   else
     return nil
   end


### PR DESCRIPTION
prefix, like: `(json:parse)`