### PR TITLE
Call path-sep form in fennel stdio's eval-file

### DIFF
--- a/fnl/conjure/client/fennel/stdio.fnl
+++ b/fnl/conjure/client/fennel/stdio.fnl
@@ -72,7 +72,7 @@
 (fn M.eval-reload []
   (let [file-path (vim.fn.expand "%")
         relative-no-suf (vim.fn.fnamemodify file-path ":.:r")
-        module-path (string.gsub relative-no-suf afs.path-sep ".")]
+        module-path (string.gsub relative-no-suf (afs.path-sep) ".")]
     (log.append [(.. M.comment-prefix ",reload " module-path)] {:break? true})
     (M.eval-str
       {:action :eval

--- a/lua/conjure/client/fennel/stdio.lua
+++ b/lua/conjure/client/fennel/stdio.lua
@@ -76,7 +76,7 @@ end
 M["eval-reload"] = function()
   local file_path = vim.fn.expand("%")
   local relative_no_suf = vim.fn.fnamemodify(file_path, ":.:r")
-  local module_path = string.gsub(relative_no_suf, afs["path-sep"], ".")
+  local module_path = string.gsub(relative_no_suf, afs["path-sep"](), ".")
   log.append({(M["comment-prefix"] .. ",reload " .. module_path)}, {["break?"] = true})
   return M["eval-str"]({action = "eval", origin = "reload", ["file-path"] = file_path, code = (",reload " .. module_path)})
 end


### PR DESCRIPTION
Was getting this error when using the `<localleader>eF` binding to reload files:

```
E5108: Lua: Vim:Lua :command callback: .../nvim/bundle/conjure/lua/conjure/client/fennel/stdio.lua:79: bad argument #2 to 'gsub' (string expected, got function) stack traceback:
        [C]: in function 'gsub'
        .../nvim/bundle/conjure/lua/conjure/client/fennel/stdio.lua:79: in function <.../nvim/bundle/conjure/lua/conjure/client/fennel/stdio.lua:76>
        [C]: at 0x010103c5dc
stack traceback:
        [C]: at 0x010103c5dc
```