### PR TITLE
Make Conjure School script run without problems

### DIFF
--- a/docs/school
+++ b/docs/school
@@ -12,6 +12,7 @@ else
 fi
 
 nvim \
+  --clean \
   --cmd "set rtp+=$PREFIX/conjure-main" \
   --cmd "source $PREFIX/conjure-main/plugin/conjure.lua" \
   -c "au VimEnter * ++nested ConjureSchool" &&


### PR DESCRIPTION
This PR should address Issue #741.

The `--clean` command line option to the `nvim` command should ensure that the Conjure School tutorial runs without having to install the Conjure plugin.