### PR TITLE
Avoid pcall on vim.treesitter.language.add as it doesn't assert/error

### DIFF
--- a/fnl/conjure/client/python/stdio.fnl
+++ b/fnl/conjure/client/python/stdio.fnl
@@ -237,7 +237,7 @@
                      (config.get-in [:mapping :prefix])
                      (cfg [:mapping :stop]))]
                 {:break? true})
-    (if (not (pcall #(ts.add-language "python")))
+    (if (not (ts.add-language "python"))
       (log.append [(.. M.comment-prefix "(error) The python client requires a python treesitter parser in order to function.")
                    (.. M.comment-prefix "(error) See https://github.com/nvim-treesitter/nvim-treesitter")
                    (.. M.comment-prefix "(error) for installation instructions.")])

--- a/fnl/conjure/tree-sitter.fnl
+++ b/fnl/conjure/tree-sitter.fnl
@@ -190,10 +190,11 @@
             node))))))
 
 (fn add-language [lang]
-  ((or vim.treesitter.language.add
-       vim.treesitter.language.require_language
-       vim.treesitter.require_language)
-   lang))
+  (let [add (case vim.treesitter
+              {:language {:add f}} f
+              {:language {:require_language f}} (partial pcall f)
+              {:require_language f} (partial pcall f))]
+    (add lang)))
 
 (fn get-root-node-for-str [lang code]
   (let [parser (vim.treesitter.get_string_parser code lang)]

--- a/lua/conjure/client/python/stdio.lua
+++ b/lua/conjure/client/python/stdio.lua
@@ -190,29 +190,26 @@ M.start = function()
   if state("repl") then
     return log.append({(M["comment-prefix"] .. "Can't start, REPL is already running."), (M["comment-prefix"] .. "Stop the REPL with " .. config["get-in"]({"mapping", "prefix"}) .. cfg({"mapping", "stop"}))}, {["break?"] = true})
   else
-    local function _21_()
-      return ts["add-language"]("python")
-    end
-    if not pcall(_21_) then
+    if not ts["add-language"]("python") then
       return log.append({(M["comment-prefix"] .. "(error) The python client requires a python treesitter parser in order to function."), (M["comment-prefix"] .. "(error) See https://github.com/nvim-treesitter/nvim-treesitter"), (M["comment-prefix"] .. "(error) for installation instructions.")})
     else
-      local function _22_()
-        local function _23_(repl)
+      local function _21_()
+        local function _22_(repl)
+          local function _23_(msgs)
+            return nil
+          end
+          repl.send("import base64\n", _23_, nil)
           local function _24_(msgs)
             return nil
           end
-          repl.send("import base64\n", _24_, nil)
-          local function _25_(msgs)
-            return nil
-          end
-          return repl.send(prep_code(M["initialise-repl-code"]), _25_, nil)
+          return repl.send(prep_code(M["initialise-repl-code"]), _24_, nil)
         end
-        return display_repl_status("started", with_repl_or_warn(_23_))
+        return display_repl_status("started", with_repl_or_warn(_22_))
       end
-      local function _26_(err)
+      local function _25_(err)
         return display_repl_status(err)
       end
-      local function _27_(code, signal)
+      local function _26_(code, signal)
         if (("number" == type(code)) and (code > 0)) then
           log.append({(M["comment-prefix"] .. "process exited with code " .. code)})
         else
@@ -223,10 +220,10 @@ M.start = function()
         end
         return M.stop()
       end
-      local function _30_(msg)
+      local function _29_(msg)
         return log.dbg(M["format-msg"](M.unbatch({msg})), {["join-first?"] = true})
       end
-      return core.assoc(state(), "repl", stdio.start({["prompt-pattern"] = cfg({"prompt-pattern"}), cmd = cfg({"command"}), ["delay-stderr-ms"] = cfg({"delay-stderr-ms"}), ["on-success"] = _22_, ["on-error"] = _26_, ["on-exit"] = _27_, ["on-stray-output"] = _30_}))
+      return core.assoc(state(), "repl", stdio.start({["prompt-pattern"] = cfg({"prompt-pattern"}), cmd = cfg({"command"}), ["delay-stderr-ms"] = cfg({"delay-stderr-ms"}), ["on-success"] = _21_, ["on-error"] = _25_, ["on-exit"] = _26_, ["on-stray-output"] = _29_}))
     end
   end
 end
@@ -234,11 +231,11 @@ M["on-exit"] = function()
   return M.stop()
 end
 M.interrupt = function()
-  local function _33_(repl)
+  local function _32_(repl)
     log.append({(M["comment-prefix"] .. " Sending interrupt signal.")}, {["break?"] = true})
     return repl["send-signal"]("sigint")
   end
-  return with_repl_or_warn(_33_)
+  return with_repl_or_warn(_32_)
 end
 M["on-load"] = function()
   if config["get-in"]({"client_on_load"}) then
@@ -248,17 +245,17 @@ M["on-load"] = function()
   end
 end
 M["on-filetype"] = function()
-  local function _35_()
+  local function _34_()
     return M.start()
   end
-  mapping.buf("PythonStart", cfg({"mapping", "start"}), _35_, {desc = "Start the Python REPL"})
-  local function _36_()
+  mapping.buf("PythonStart", cfg({"mapping", "start"}), _34_, {desc = "Start the Python REPL"})
+  local function _35_()
     return M.stop()
   end
-  mapping.buf("PythonStop", cfg({"mapping", "stop"}), _36_, {desc = "Stop the Python REPL"})
-  local function _37_()
+  mapping.buf("PythonStop", cfg({"mapping", "stop"}), _35_, {desc = "Stop the Python REPL"})
+  local function _36_()
     return M.interrupt()
   end
-  return mapping.buf("PythonInterrupt", cfg({"mapping", "interrupt"}), _37_, {desc = "Interrupt the current evaluation"})
+  return mapping.buf("PythonInterrupt", cfg({"mapping", "interrupt"}), _36_, {desc = "Interrupt the current evaluation"})
 end
 return M

--- a/lua/conjure/tree-sitter.lua
+++ b/lua/conjure/tree-sitter.lua
@@ -162,7 +162,29 @@ local function get_form(node)
   end
 end
 local function add_language(lang)
-  return (vim.treesitter.language.add or vim.treesitter.language.require_language or vim.treesitter.require_language)(lang)
+  local add
+  do
+    local case_25_ = vim.treesitter
+    if ((_G.type(case_25_) == "table") and ((_G.type(case_25_.language) == "table") and (nil ~= case_25_.language.add))) then
+      local f = case_25_.language.add
+      add = f
+    elseif ((_G.type(case_25_) == "table") and ((_G.type(case_25_.language) == "table") and (nil ~= case_25_.language.require_language))) then
+      local f = case_25_.language.require_language
+      local function _26_(...)
+        return pcall(f, ...)
+      end
+      add = _26_
+    elseif ((_G.type(case_25_) == "table") and (nil ~= case_25_.require_language)) then
+      local f = case_25_.require_language
+      local function _27_(...)
+        return pcall(f, ...)
+      end
+      add = _27_
+    else
+      add = nil
+    end
+  end
+  return add(lang)
 end
 local function get_root_node_for_str(lang, code)
   local parser = vim.treesitter.get_string_parser(code, lang)


### PR DESCRIPTION
`pcall`-ing `vim.treesitter.language.add` would always return true as its first result value, as `add` uses the style of returning nil and an error message when it can't add the language rather than aborting via `error` or `assert`. This causes an issue when a Conjure user opens a Python buffer but doesn't have a Python treesitter parser installed. Conjure thinks they _do_ have a parser installed and tries to start the stdio client. The user would see an error from Neovim's treesitter code like `vim.schedule: No parser for language "python"`, and not the stdio client's intended log messages for this case (reproduced below) which made it difficult to identify that the error was originating from Conjure.

```
(error) The python client requires a python treesitter parser in order to function.
(error) See https://github.com/nvim-treesitter/nvim-treesitter
(error) for installation instructions.
```

The style of return nil plus error message is a change from the now-deprecated `require_language` functions that Conjure's `add-language` also wraps for backwards-compatiblity. The `pcall` was previously around the `add-language` wrapper call in the Python stdio client's `start` function. These changes move the choice to `pcall` or not into the `add-language` wrapper itself. This lets `add` skip a `pcall` while the deprecated `require_language` functions still get a `pcall`.