### PR TITLE
Python client was doing some on-success init inside call to display-repl-status

### DIFF
--- a/fnl/conjure/client/python/stdio.fnl
+++ b/fnl/conjure/client/python/stdio.fnl
@@ -250,8 +250,8 @@
 
            :on-success
            (fn []
-             (display-repl-status :started
-              (with-repl-or-warn
+             (display-repl-status :started)
+             (with-repl-or-warn
                (fn [repl]
                  (repl.send
                    "import base64\n"
@@ -260,7 +260,7 @@
                  (repl.send
                    (prep-code M.initialise-repl-code)
                    (fn [msgs] nil)
-                   nil)))))
+                   nil))))
 
            :on-error
            (fn [err]

--- a/lua/conjure/client/python/stdio.lua
+++ b/lua/conjure/client/python/stdio.lua
@@ -197,6 +197,7 @@ M.start = function()
       return log.append({(M["comment-prefix"] .. "(error) The python client requires a python treesitter parser in order to function."), (M["comment-prefix"] .. "(error) See https://github.com/nvim-treesitter/nvim-treesitter"), (M["comment-prefix"] .. "(error) for installation instructions.")})
     else
       local function _22_()
+        display_repl_status("started")
         local function _23_(repl)
           local function _24_(msgs)
             return nil
@@ -207,7 +208,7 @@ M.start = function()
           end
           return repl.send(prep_code(M["initialise-repl-code"]), _25_, nil)
         end
-        return display_repl_status("started", with_repl_or_warn(_23_))
+        return with_repl_or_warn(_23_)
       end
       local function _26_(err)
         return display_repl_status(err)


### PR DESCRIPTION
In the Python stdio client's `on-success`, the `with-repl-or-warn` call was accidentally within the `display-repl-status` call (`display-repl-status` is only meant to take a single status arg). Looking at the previous generated Lua, this wasn't causing a problem as the `with-repl-or-warn` block was still getting called. These changes are more to avoid future confusion and mixups.