### PR TITLE
Set `math.randomseed` before generating sponsor message

### DIFF
--- a/fnl/conjure/log.fnl
+++ b/fnl/conjure/log.fnl
@@ -53,6 +53,7 @@
     (vim.treesitter.stop buf)
     (tset vim.bo buf :syntax "on"))
 
+  (math.randomseed (os.time))
   (vim.api.nvim_buf_set_lines
     buf 0 -1 false
     [(str.join [(client.get :comment-prefix)

--- a/lua/conjure/log.lua
+++ b/lua/conjure/log.lua
@@ -42,6 +42,7 @@ local function on_new_log_buf(buf)
     vim.bo[buf]["syntax"] = "on"
   else
   end
+  math.randomseed(os.time())
   return vim.api.nvim_buf_set_lines(buf, 0, -1, false, {str.join({client.get("comment-prefix"), "Sponsored by @", core.get(sponsors, core.inc(math.floor(core.rand(core.dec(core.count(sponsors)))))), " \226\157\164"})})
 end
 local function upsert_buf()


### PR DESCRIPTION
As explained in the [docstring](https://github.com/Olical/nfnl/blob/fecf731e02bc51d88372c4f992fe1ef0c19c02ae/fnl/nfnl/core.fnl#L6C3-L6C86) to `nfnl.core/rand`:

> You must have a random seed set before running this: `(math.randomseed (os.time))`

At present, Conjure does not do this and as a result the sponsor message is not selecting a random sponsor (unless the user happens to call `math.randomseed` within their Neovim environment).

This commit adds the call recommended in the docstring.