### PR TITLE
Fix for issue #756.

### DIFF
--- a/lua/conjure/tree-sitter-completions.lua
+++ b/lua/conjure/tree-sitter-completions.lua
@@ -3,7 +3,6 @@ local _local_1_ = require("conjure.nfnl.module")
 local autoload = _local_1_.autoload
 local define = _local_1_.define
 local a = autoload("conjure.nfnl.core")
-local log = autoload("conjure.log")
 local ts = autoload("conjure.tree-sitter")
 local util = autoload("conjure.util")
 local res = autoload("conjure.resources")
@@ -100,6 +99,7 @@ local function get_node_text(node, buffer, meta)
   end
 end
 local function get_completions_for_query(query)
+  ts["parse!"]()
   local buffer = vim.api.nvim_get_current_buf()
   local cursor_node = vim.treesitter.get_node()
   local row, _ = unpack(vim.api.nvim_win_get_cursor(0))


### PR DESCRIPTION
This PR should address Issue #756.

The initial error reported led to discovery of a problem with the completion function for the Scheme, Guile, and Common Lisp clients. As it turns out, the `attempt to index local 'cursor_node' (a nil value)` message was the key to finding a solution.

The main problem lies with not calling `vim.treesitter.get_node` before the buffer is parsed by the parser method on `vim.treesitter.get_parser` on the current buffer for the filetype of the buffer. Luckily, there is already code in place to help so it takes just one line to resolve this issue. Also, this change will fix three Conjure client because they all call `get-completions-at-cursor` in `conjure.tree-sitter-completions`.

L.3 and L.86 are the main fix. The other changes are cosmetic whitespace removal.