### PR TITLE
Make `conjure#client_on_load` option control nREPL popup on Clojure file open

### DIFF
--- a/doc/conjure-client-clojure-nrepl.txt
+++ b/doc/conjure-client-clojure-nrepl.txt
@@ -161,6 +161,13 @@ CONFIGURATION                     *conjure-client-clojure-nrepl-configuration*
 
 All configuration can be set as described in |conjure-configuration|.
 
+                      *g:conjure#client_on_load*
+`g:conjure#client_on_load`
+            When loading a Clojure file for the first time, connect to a
+            REPL automatically. If `false`, Conjure will still auto-connect
+            when you first eval something.
+            Default: `true`
+
                       *g:conjure#client#clojure#nrepl#connection#default_host*
 `g:conjure#client#clojure#nrepl#connection#default_host`
             When connecting to port files or via `:ConjureConnect` this is the

--- a/fnl/conjure/client/clojure/nrepl/init.fnl
+++ b/fnl/conjure/client/clojure/nrepl/init.fnl
@@ -341,7 +341,9 @@
   (action.passive-ns-require))
 
 (fn M.on-load []
-  (action.connect-port-file))
+  ;; Start up REPL only if g.conjure#client_on_load is v:true.
+  (when (config.get-in [:client_on_load])
+    (action.connect-port-file)))
 
 (fn M.on-exit []
   (auto-repl.delete-auto-repl-port-file)

--- a/lua/conjure/client/clojure/nrepl/init.lua
+++ b/lua/conjure/client/clojure/nrepl/init.lua
@@ -125,7 +125,11 @@ M["on-filetype"] = function()
   return action["passive-ns-require"]()
 end
 M["on-load"] = function()
-  return action["connect-port-file"]()
+  if config["get-in"]({"client_on_load"}) then
+    return action["connect-port-file"]()
+  else
+    return nil
+  end
 end
 M["on-exit"] = function()
   auto_repl["delete-auto-repl-port-file"]()


### PR DESCRIPTION
## Overview 

Users might be interested in suppressing the nREPL connection popup when first loading a Clojure file. I personally found it quite distracting, especially when just quickly trying to read a Clojure file with no intention of starting a REPL to do work.

This commit makes the setting `conjure#client_on_load` control that auto nREPL connection on or off. Note that when set to `false`, Conjure will still auto connect when a form is evaluated as noted in the configuration text file. You can also see it in action in the demo video.  

## Demo

**Before**:

https://github.com/user-attachments/assets/1c27cc35-7f98-416e-a74f-ecf01e09cc18


**With `client_on_load` set to `false`**


https://github.com/user-attachments/assets/edb7ae76-6b21-425e-941c-186ee2f11f2e

Notice I load the file and the connection popup doesn't appear. Only when I evaluate a form does it appear, and you can see it still auto connects. 


## p.s.

I am very open to suggestions! This is just something about Conjure I found particularly annoying and I would love to see it merged.