### PR TITLE
Update Python client docs for client_on_load

### DIFF
--- a/doc/conjure-client-python-stdio.txt
+++ b/doc/conjure-client-python-stdio.txt
@@ -51,6 +51,12 @@ CONFIGURATION                        *conjure-client-python-stdio-configuration*
 
 All configuration can be set as described in |conjure-configuration|.
 
+                                                    *g:conjure#client_on_load*
+`g:conjure#client_on_load`
+            A Python REPL is automatically started when a Python source file
+            is loaded. To not have this happen, set this configuration item to
+            `false`. See the entry in |conjure-configuration|.
+            Default: `true`
 
                                  *g:conjure#client#python#stdio#mapping#start*
 `g:conjure#client#python#stdio#mapping#start`


### PR DESCRIPTION
PR #760 reminded me that I forgot to add an item in the Python client's help doc to say that the client does observe the `g:conjure#client_on_load` configuration. It will not automatically start a connection to a Python REPL when the first Python source file is loaded.