### PR TITLE
fix(julia): add `field_expression` and `scoped_identifier` ts-nodes for doc-word

### DIFF
--- a/fnl/conjure/tree-sitter.fnl
+++ b/fnl/conjure/tree-sitter.fnl
@@ -91,6 +91,7 @@
   (when node
     (or (string.find (node:type) :sym)
         (= (node:type) :package_lit) ;; just for common lisp
+        (vim.tbl_contains [:field_expression :scoped_identifier] (node:type)) ;; just for julia
         (client.optional-call :symbol-node? node))))
 
 (fn get-leaf [node]

--- a/lua/conjure/tree-sitter.lua
+++ b/lua/conjure/tree-sitter.lua
@@ -89,7 +89,7 @@ local function leaf_3f(node)
 end
 local function sym_3f(node)
   if node then
-    return (string.find(node:type(), "sym") or (node:type() == "package_lit") or client["optional-call"]("symbol-node?", node))
+    return (string.find(node:type(), "sym") or (node:type() == "package_lit") or vim.tbl_contains({"field_expression", "scoped_identifier"}, node:type()) or client["optional-call"]("symbol-node?", node))
   else
     return nil
   end


### PR DESCRIPTION
## function call

- old:
HTTP.get(...) -> doc-word `get`
----------^
- new:
HTTP.get(...) -> doc-word `HTTP.get`
----------^

## using statement

- old:
using Base.Iterators -> doc-word `Iterators`
--------------------^
- new:
using Base.Iterators -> doc-word `Base.Iterators`
--------------------^