### PR TITLE
Remove duplicate help tag in Python client doc

### DIFF
--- a/doc/conjure-client-python-stdio.txt
+++ b/doc/conjure-client-python-stdio.txt
@@ -51,13 +51,6 @@ CONFIGURATION                        *conjure-client-python-stdio-configuration*
 
 All configuration can be set as described in |conjure-configuration|.
 
-                                                    *g:conjure#client_on_load*
-`g:conjure#client_on_load`
-            A Python REPL is automatically started when a Python source file
-            is loaded. To not have this happen, set this configuration item to
-            `false`. See the entry in |conjure-configuration|.
-            Default: `true`
-
                                  *g:conjure#client#python#stdio#mapping#start*
 `g:conjure#client#python#stdio#mapping#start`
             Start the Python REPL if it's not running already.


### PR DESCRIPTION
This should correct the problem with the help doc for Conjure failing to generate. See PR #764. 