### PR TITLE
JS/TS: Improved DX for transformation errors, proper multiline string handling, type import fixes, and other minor improvements.

### DIFF
--- a/dev/javascript/sandbox.js
+++ b/dev/javascript/sandbox.js
@@ -143,3 +143,10 @@ function thisBody() {
 
 const tb = thisBody();
 tb.get()
+
+let msg = `await 
+            booboo`
+
+msg
+
+export { arrowThis }

--- a/dev/typescript/sandbox.ts
+++ b/dev/typescript/sandbox.ts
@@ -335,7 +335,25 @@ expFn()
 export function funFun() { return "export function Fun" }
 export { }
 
-const arrowThis = () => {
-  let a = 1;
-  return this.a + 1;
-}
+// const arrowThis = () => {
+//   let a = 1;
+//   return this.a + 1;
+// }
+//
+// class Foo {
+//   a: number;
+//   fn: () => number;
+//   constructor() {
+//     this.a = 1
+//     this.fn = () => this.a
+//   }
+// }
+//
+// let foooooo = new Foo()
+// foooooo.fn()
+//
+//
+// let msg = `a 
+//            b`
+//
+// msg

--- a/doc/conjure-client-javascript-stdio.txt
+++ b/doc/conjure-client-javascript-stdio.txt
@@ -37,8 +37,7 @@ TypeScript support:
    {
      "ts-node": {
        // ts-node config here
-       }
-     },
+       },
      "compilerOptions": {
          "target": "es2022",
          "module": "es2022"

--- a/fnl/conjure/client/javascript/import-replacer.fnl
+++ b/fnl/conjure/client/javascript/import-replacer.fnl
@@ -18,7 +18,8 @@
 (fn is-type-import? [node code]
   (let [first-child (node:child 0)
         second-child (node:child 1)
-        contains-type (string.find (tsc.get-text second-child code) "type")]
+        contains-type (and second-child
+                           (string.find (tsc.get-text second-child code) "type"))]
     (or (and first-child
          (= (tsc.get-text first-child code) "import")
          second-child

--- a/fnl/conjure/client/javascript/stdio.fnl
+++ b/fnl/conjure/client/javascript/stdio.fnl
@@ -68,8 +68,7 @@
 
 (fn M.format-msg [msg]
   (->> (str.split msg "\n")
-       (a.filter #(not= "" $1))
-       (a.map #(replace-dots $1 ""))))
+       (a.filter #(not= "" $1))))
 
 (fn sanitize-msg [msg field]
   (->> (str.split (a.get msg field) "\n")

--- a/fnl/conjure/client/javascript/transformers.fnl
+++ b/fnl/conjure/client/javascript/transformers.fnl
@@ -133,7 +133,8 @@
            _ (node-handlers.default child code)))))
 
 (each [_ t (pairs
-             [:expression_statement
+             [:type_alias_declaration
+              :expression_statement
               :variable_declaration
               :return_statement
               :throw_statement

--- a/fnl/conjure/client/javascript/transformers.fnl
+++ b/fnl/conjure/client/javascript/transformers.fnl
@@ -95,15 +95,13 @@
   (let [body-node (tsc.get-child arrow-fn "body")
         forbidden (body-contains-forbidden-keyword? body-node code)]
     (if forbidden
-        (let [(ln col) (forbidden:start)
-              par (arrow-fn:parent)
-              par (handle-statement (par:parent) code)]
+        (let [(ln col) (forbidden:start) ]
           (handle-transform-error
             {:type :warn
              :info (.. "Cannot transform arrow function, it contains '" (forbidden:type) "'")
              :ln ln
              :col col})
-          par)
+          nil)
         (let [params (tsc.get-text (tsc.get-child arrow-fn "parameters") code)
               body-text (transform body-node code)
               first-child (arrow-fn:child 0)
@@ -123,7 +121,8 @@
                              (tsc.get-child var-decl "value"))]
          (if (and value-node (= "arrow_function" (value-node:type)))
              (let [name (tsc.get-text (tsc.get-child var-decl "name") code)]
-               (transform-arrow-fn value-node name code))
+               (or (transform-arrow-fn value-node name code)
+                   (handle-statement node code)))
              (handle-statement node code)))))
 
 (set node-handlers.member_expression

--- a/fnl/conjure/client/javascript/transformers.fnl
+++ b/fnl/conjure/client/javascript/transformers.fnl
@@ -9,16 +9,25 @@
 
 (var node-handlers {})
 
+(local err-type->str
+  {:err "ERROR"
+   :warn "WARNING"})
+
+(fn table? [e] (= "table" (type e)) )
+
 (fn handle-transform-error [err]
-  (let [opts (or (. eval.previous-evaluations  "conjure.client.javascript.stdio") {})
+  (let [opts (or (. eval.previous-evaluations "conjure.client.javascript.stdio") {})
         {:range range} opts
         {:start start} (or range {})
         [line col] (or start [])
-        {:ln eline :col ecol :info einfo} (if (= "table" (type err)) err {})
+        err (if (table? err) err {})
+        {:ln eline :col ecol :info einfo :type tp} err
+        tp (or (. err-type->str tp) "ERROR")
         final-line (+ (or line 0) (or eline 0)) 
         final-col (if ecol (+ 1 ecol) col)
-        info (or einfo "no info")]
-    (log.append [(.. "/* [ERROR] transforming node " 
+        info (or einfo "no info")
+        pref (.. "[" tp "]")]
+    (log.append [(.. "/* " pref " transforming node "
                      "at line " final-line
                      " column " final-col
                      ". Info: " info " */")])))
@@ -29,20 +38,26 @@
         (_ok result) (xpcall (fn [] (handler node code)) handle-transform-error)]
     result))
 
+(fn subs-newline [code start prev-end]
+  (let [subs (string.sub code (+ prev-end 1) start)
+        subs (string.gsub subs "[\r\n]+" " ")
+        (subs _) subs]
+    subs))
+
 (set node-handlers.default
      (fn [node code]
        (if (= (node:child_count) 0)
            (tsc.get-text node code)
-           (let [pieces []]
-             (var prev-end (let [(_ _ b) (node:start)] b))
+           (let [pieces []
+                 prev-end {:val (let [(_ _ b) (node:start)] b)}]
              (each [child (node:iter_children)]
                (let [(_ _ start) (child:start)
-                     (_ _ stop) (child:end_)]
-                 (table.insert pieces (string.sub code (+ prev-end 1) start))
+                     (_ _ end) (child:end_)]
+                 (table.insert pieces (subs-newline code start prev-end.val))
                  (table.insert pieces (transform child code))
-                 (set prev-end stop)))
-             (table.insert pieces (string.sub code (+ prev-end 1) (let [(_ _ end) (node:end_)] end)))
-             (table.concat pieces "")))))
+                 (set prev-end.val end)))
+             (table.insert pieces (subs-newline code (let [(_ _ end) (node:end_)] end) prev-end.val))
+             (table.concat (a.remove (fn [p] (>= 0 (string.len p))) pieces) "")))))
 
 (set node-handlers.comment
   (fn [_ _] ""))
@@ -67,14 +82,28 @@
               (table.insert stack c)))))
     found))
 
+(fn handle-statement [node code]
+  (let [text (node-handlers.default node code)
+        trimmed (vim.fn.trim text)
+        last-char (string.sub trimmed -1)]
+    (if (or (= last-char ";")
+            (= last-char ":"))
+        text
+        (.. text ";"))))
+
 (fn transform-arrow-fn [arrow-fn name code]
   (let [body-node (tsc.get-child arrow-fn "body")
         forbidden (body-contains-forbidden-keyword? body-node code)]
     (if forbidden
-        (let [(ln col) (forbidden:start)]
-          (error {:info (.. "Cannot transform arrow function, it contains '" (forbidden:type) "'")
-                  :ln ln
-                  :col col}))
+        (let [(ln col) (forbidden:start)
+              par (arrow-fn:parent)
+              par (handle-statement (par:parent) code)]
+          (handle-transform-error
+            {:type :warn
+             :info (.. "Cannot transform arrow function, it contains '" (forbidden:type) "'")
+             :ln ln
+             :col col})
+          par)
         (let [params (tsc.get-text (tsc.get-child arrow-fn "parameters") code)
               body-text (transform body-node code)
               first-child (arrow-fn:child 0)
@@ -84,16 +113,7 @@
                            "statement_block" (.. " " body-text)
                            "parenthesized_expression" (.. " { return " body-text " }")
                            _ (.. " { return " body-text " }"))]
-          (.. async-kw "function " name params final-body)))))
-
-(fn handle-statement [node code]
-  (let [text (node-handlers.default node code)
-        trimmed (vim.fn.trim text)
-        last-char (string.sub trimmed -1)]
-    (if (or (= last-char ";")
-            (= last-char ":"))
-        text
-        (.. text ";"))))
+          (.. async-kw "function " name params final-body ";")))))
 
 (set node-handlers.lexical_declaration
      (fn [node code]
@@ -144,7 +164,7 @@
               :class_declaration
               :field_definition
               :public_field_definition
-              :function_declaration ])]
+              :function_declaration])]
 
   (set (. node-handlers t) handle-statement))
 
@@ -152,6 +172,6 @@
   (let [tree (tsc.get-tree s)
         root (tree:root)
         transformed (transform root s)]
-    (string.gsub transformed "%s*\n%s*" " ")))
+    (vim.fn.trim transformed)))
 
 M

--- a/lua/conjure/client/javascript/import-replacer.lua
+++ b/lua/conjure/client/javascript/import-replacer.lua
@@ -15,7 +15,7 @@ end
 local function is_type_import_3f(node, code)
   local first_child = node:child(0)
   local second_child = node:child(1)
-  local contains_type = string.find(tsc["get-text"](second_child, code), "type")
+  local contains_type = (second_child and string.find(tsc["get-text"](second_child, code), "type"))
   return ((first_child and (tsc["get-text"](first_child, code) == "import") and second_child and (tsc["get-text"](second_child, code) == "type")) or contains_type)
 end
 local function clean_named_imports(node, code)

--- a/lua/conjure/client/javascript/stdio.lua
+++ b/lua/conjure/client/javascript/stdio.lua
@@ -54,24 +54,21 @@ local function replace_dots(s, with)
 end
 M["format-msg"] = function(msg)
   local function _5_(_241)
-    return replace_dots(_241, "")
-  end
-  local function _6_(_241)
     return ("" ~= _241)
   end
-  return a.map(_5_, a.filter(_6_, str.split(msg, "\n")))
+  return a.filter(_5_, str.split(msg, "\n"))
 end
 local function sanitize_msg(msg, field)
-  local function _7_(_241)
+  local function _6_(_241)
     return ("(" .. field .. ") " .. _241 .. "\n")
   end
-  local function _8_(...)
+  local function _7_(...)
     return not str["blank?"](...)
   end
-  local function _9_(_241)
+  local function _8_(_241)
     return replace_dots(_241, "")
   end
-  return str.join("", a.map(_7_, a.filter(_8_, a.map(_9_, str.split(a.get(msg, field), "\n")))))
+  return str.join("", a.map(_6_, a.filter(_7_, a.map(_8_, str.split(a.get(msg, field), "\n")))))
 end
 local function prepare_out(msg)
   if a.get(msg, "out") then
@@ -101,8 +98,8 @@ local function restart()
   return M.start()
 end
 M["eval-str"] = function(opts)
-  local function _12_(repl)
-    local function _13_(msgs)
+  local function _11_(repl)
+    local function _12_(msgs)
       local msgs0 = M["format-msg"](M.unbatch(msgs))
       display_result(msgs0)
       if opts["on-result"] then
@@ -111,9 +108,9 @@ M["eval-str"] = function(opts)
         return nil
       end
     end
-    return repl.send(prep_code(opts.code), _13_, {["batch?"] = true})
+    return repl.send(prep_code(opts.code), _12_, {["batch?"] = true})
   end
-  return with_repl_or_warn(_12_)
+  return with_repl_or_warn(_11_)
 end
 M["eval-file"] = function(opts)
   return M["eval-str"](a.assoc(opts, "code", a.slurp(opts["file-path"])))
@@ -150,24 +147,24 @@ M.start = function()
   if state("repl") then
     return log.append({(M["comment-prefix"] .. "Can't start, REPL is already running."), (M["comment-prefix"] .. "Stop the REPL with " .. config["get-in"]({"mapping", "prefix"}) .. cfg({"mapping", "stop"}))}, {["break?"] = true})
   else
-    local function _18_()
+    local function _17_()
       display_repl_status("started")
       do
         local repl = state("repl")
         repl.send("1+1;")
       end
-      local function _19_(repl)
-        local function _20_(msgs)
+      local function _18_(repl)
+        local function _19_(msgs)
           return display_result(M["format-msg"](M.unbatch(msgs)))
         end
-        return repl.send(prep_code(M["initialise-repl-code"]), _20_, {batch = true})
+        return repl.send(prep_code(M["initialise-repl-code"]), _19_, {batch = true})
       end
-      return with_repl_or_warn(_19_)
+      return with_repl_or_warn(_18_)
     end
-    local function _21_(err)
+    local function _20_(err)
       return display_repl_status(err)
     end
-    local function _22_(code, signal)
+    local function _21_(code, signal)
       if (("number" == type(code)) and (code > 0)) then
         log.append({(M["comment-prefix"] .. "process exited with code " .. code)})
       else
@@ -178,21 +175,21 @@ M.start = function()
       end
       return M.stop()
     end
-    local function _25_(msg)
+    local function _24_(msg)
       if cfg({"show_stray_out"}) then
         return display_result(M["format-msg"](M.unbatch({msg})))
       else
         return nil
       end
     end
-    return a.assoc(state(), "repl", stdio.start({["prompt-pattern"] = cfg({"prompt_pattern"}), cmd = (repl_command_for_filetype() .. " " .. cfg({"args"})), ["delay-stderr-ms"] = cfg({"delay-stderr-ms"}), ["on-success"] = _18_, ["on-error"] = _21_, ["on-exit"] = _22_, ["on-stray-output"] = _25_}))
+    return a.assoc(state(), "repl", stdio.start({["prompt-pattern"] = cfg({"prompt_pattern"}), cmd = (repl_command_for_filetype() .. " " .. cfg({"args"})), ["delay-stderr-ms"] = cfg({"delay-stderr-ms"}), ["on-success"] = _17_, ["on-error"] = _20_, ["on-exit"] = _21_, ["on-stray-output"] = _24_}))
   end
 end
 local function warning_msg()
-  local function _28_(_241)
+  local function _27_(_241)
     return log.append({_241})
   end
-  return a.map(_28_, {"// WARNING! Node.js REPL limitations require transformations:", "// 1. ES6 'import' statements are converted to 'require(...)' calls.", "// 2. Arrow functions ('const fn = () => ...') are converted to 'function fn() ...' declarations to allow re-definition."})
+  return a.map(_27_, {"// WARNING! Node.js REPL limitations require transformations:", "// 1. ES6 'import' statements are converted to 'require(...)' calls.", "// 2. Arrow functions ('const fn = () => ...') are converted to 'function fn() ...' declarations to allow re-definition."})
 end
 M["on-load"] = function()
   if config["get-in"]({"client_on_load"}) then
@@ -206,11 +203,11 @@ M["on-exit"] = function()
   return M.stop()
 end
 M.interrupt = function()
-  local function _30_(repl)
+  local function _29_(repl)
     log.append({(M["comment-prefix"] .. " Sending interrupt signal.")}, {["break?"] = true})
     return repl["send-signal"]("sigint")
   end
-  return with_repl_or_warn(_30_)
+  return with_repl_or_warn(_29_)
 end
 M["on-filetype"] = function()
   mapping.buf("JavascriptStart", cfg({"mapping", "start"}), M.start, {desc = "Start the Javascript REPL"})

--- a/lua/conjure/client/javascript/transformers.lua
+++ b/lua/conjure/client/javascript/transformers.lua
@@ -9,6 +9,10 @@ local log = autoload("conjure.log")
 local a = autoload("conjure.nfnl.core")
 local M = define("conjure.client.javascript.transformers")
 local node_handlers = {}
+local err_type__3estr = {err = "ERROR", warn = "WARNING"}
+local function table_3f(e)
+  return ("table" == type(e))
+end
 local function handle_transform_error(err)
   local opts = (eval["previous-evaluations"]["conjure.client.javascript.stdio"] or {})
   local range = opts.range
@@ -17,17 +21,17 @@ local function handle_transform_error(err)
   local _let_3_ = (start or {})
   local line = _let_3_[1]
   local col = _let_3_[2]
-  local function _4_()
-    if ("table" == type(err)) then
-      return err
-    else
-      return {}
-    end
+  local err0
+  if table_3f(err) then
+    err0 = err
+  else
+    err0 = {}
   end
-  local _let_5_ = _4_()
-  local eline = _let_5_.ln
-  local ecol = _let_5_.col
-  local einfo = _let_5_.info
+  local eline = err0.ln
+  local ecol = err0.col
+  local einfo = err0.info
+  local tp = err0.type
+  local tp0 = (err_type__3estr[tp] or "ERROR")
   local final_line = ((line or 0) + (eline or 0))
   local final_col
   if ecol then
@@ -36,48 +40,61 @@ local function handle_transform_error(err)
     final_col = col
   end
   local info = (einfo or "no info")
-  return log.append({("/* [ERROR] transforming node " .. "at line " .. final_line .. " column " .. final_col .. ". Info: " .. info .. " */")})
+  local pref = ("[" .. tp0 .. "]")
+  return log.append({("/* " .. pref .. " transforming node " .. "at line " .. final_line .. " column " .. final_col .. ". Info: " .. info .. " */")})
 end
 local function transform(node, code)
   local node_type = node:type()
   local handler = (node_handlers[node_type] or node_handlers.default)
   local _ok, result
-  local function _7_()
+  local function _6_()
     return handler(node, code)
   end
-  _ok, result = xpcall(_7_, handle_transform_error)
+  _ok, result = xpcall(_6_, handle_transform_error)
   return result
 end
-local function _8_(node, code)
+local function subs_newline(code, start, prev_end)
+  local subs = string.sub(code, (prev_end + 1), start)
+  local subs0 = string.gsub(subs, "[\r\n]+", " ")
+  local subs1, _ = subs0
+  return subs1
+end
+local function _7_(node, code)
   if (node:child_count() == 0) then
     return tsc["get-text"](node, code)
   else
     local pieces = {}
     local prev_end
+    local _8_
     do
       local _, _0, b = node:start()
-      prev_end = b
+      _8_ = b
     end
+    prev_end = {val = _8_}
     for child in node:iter_children() do
       local _, _0, start = child:start()
-      local _1, _2, stop = child:end_()
-      table.insert(pieces, string.sub(code, (prev_end + 1), start))
+      local _1, _2, _end = child:end_()
+      table.insert(pieces, subs_newline(code, start, prev_end.val))
       table.insert(pieces, transform(child, code))
-      prev_end = stop
+      prev_end.val = _end
     end
-    local function _9_()
+    local _9_
+    do
       local _, _0, _end = node:end_()
-      return _end
+      _9_ = _end
     end
-    table.insert(pieces, string.sub(code, (prev_end + 1), _9_()))
-    return table.concat(pieces, "")
+    table.insert(pieces, subs_newline(code, _9_, prev_end.val))
+    local function _10_(p)
+      return (0 >= string.len(p))
+    end
+    return table.concat(a.remove(_10_, pieces), "")
   end
 end
-node_handlers.default = _8_
-local function _11_(_, _0)
+node_handlers.default = _7_
+local function _12_(_, _0)
   return ""
 end
-node_handlers.comment = _11_
+node_handlers.comment = _12_
 local function forbidden_kw_3f(n, code)
   local t = n:type()
   local txt = tsc["get-text"](n, code)
@@ -98,12 +115,25 @@ local function body_contains_forbidden_keyword_3f(node, code)
   end
   return found
 end
+local function handle_statement(node, code)
+  local text = node_handlers.default(node, code)
+  local trimmed = vim.fn.trim(text)
+  local last_char = string.sub(trimmed, -1)
+  if ((last_char == ";") or (last_char == ":")) then
+    return text
+  else
+    return (text .. ";")
+  end
+end
 local function transform_arrow_fn(arrow_fn, name, code)
   local body_node = tsc["get-child"](arrow_fn, "body")
   local forbidden = body_contains_forbidden_keyword_3f(body_node, code)
   if forbidden then
     local ln, col = forbidden:start()
-    return error({info = ("Cannot transform arrow function, it contains '" .. forbidden:type() .. "'"), ln = ln, col = col})
+    local par = arrow_fn:parent()
+    local par0 = handle_statement(par:parent(), code)
+    handle_transform_error({type = "warn", info = ("Cannot transform arrow function, it contains '" .. forbidden:type() .. "'"), ln = ln, col = col})
+    return par0
   else
     local params = tsc["get-text"](tsc["get-child"](arrow_fn, "parameters"), code)
     local body_text = transform(body_node, code)
@@ -117,30 +147,20 @@ local function transform_arrow_fn(arrow_fn, name, code)
     end
     local final_body
     do
-      local case_14_ = body_node:type()
-      if (case_14_ == "statement_block") then
+      local case_16_ = body_node:type()
+      if (case_16_ == "statement_block") then
         final_body = (" " .. body_text)
-      elseif (case_14_ == "parenthesized_expression") then
+      elseif (case_16_ == "parenthesized_expression") then
         final_body = (" { return " .. body_text .. " }")
       else
-        local _ = case_14_
+        local _ = case_16_
         final_body = (" { return " .. body_text .. " }")
       end
     end
-    return (async_kw .. "function " .. name .. params .. final_body)
+    return (async_kw .. "function " .. name .. params .. final_body .. ";")
   end
 end
-local function handle_statement(node, code)
-  local text = node_handlers.default(node, code)
-  local trimmed = vim.fn.trim(text)
-  local last_char = string.sub(trimmed, -1)
-  if ((last_char == ";") or (last_char == ":")) then
-    return text
-  else
-    return (text .. ";")
-  end
-end
-local function _18_(node, code)
+local function _19_(node, code)
   local var_decl = node:child(1)
   local value_node = (var_decl and (var_decl:type() == "variable_declarator") and tsc["get-child"](var_decl, "value"))
   if (value_node and ("arrow_function" == value_node:type())) then
@@ -150,8 +170,8 @@ local function _18_(node, code)
     return handle_statement(node, code)
   end
 end
-node_handlers.lexical_declaration = _18_
-local function _20_(node, code)
+node_handlers.lexical_declaration = _19_
+local function _21_(node, code)
   local obj = node:field("object")[1]
   if (obj and ((obj:type() == "call_expression") or (obj:type() == "member_expression"))) then
     local default_text = node_handlers.default(node, code)
@@ -161,22 +181,22 @@ local function _20_(node, code)
     return node_handlers.default(node, code)
   end
 end
-node_handlers.member_expression = _20_
+node_handlers.member_expression = _21_
 node_handlers.import_statement = ir["import-statement"](handle_statement)
 node_handlers.call_expression = ir["call-expression"](node_handlers.default)
-local function _22_(node, code)
+local function _23_(node, code)
   local child = node:child(1)
-  local case_23_ = child:type()
-  if ((case_23_ == "interface_declaration") or (case_23_ == "class_declaration")) then
+  local case_24_ = child:type()
+  if ((case_24_ == "interface_declaration") or (case_24_ == "class_declaration")) then
     return node_handlers.default(node, code)
-  elseif (case_23_ == "export_clause") then
+  elseif (case_24_ == "export_clause") then
     return ""
   else
-    local _ = case_23_
+    local _ = case_24_
     return node_handlers.default(child, code)
   end
 end
-node_handlers.export_statement = _22_
+node_handlers.export_statement = _23_
 for _, t in pairs({"type_alias_declaration", "expression_statement", "variable_declaration", "return_statement", "throw_statement", "break_statement", "continue_statement", "debugger_statement", "class_declaration", "field_definition", "public_field_definition", "function_declaration"}) do
   node_handlers[t] = handle_statement
 end
@@ -184,6 +204,6 @@ M.transform = function(s)
   local tree = tsc["get-tree"](s)
   local root = tree:root()
   local transformed = transform(root, s)
-  return string.gsub(transformed, "%s*\n%s*", " ")
+  return vim.fn.trim(transformed)
 end
 return M

--- a/lua/conjure/client/javascript/transformers.lua
+++ b/lua/conjure/client/javascript/transformers.lua
@@ -177,7 +177,7 @@ local function _22_(node, code)
   end
 end
 node_handlers.export_statement = _22_
-for _, t in pairs({"expression_statement", "variable_declaration", "return_statement", "throw_statement", "break_statement", "continue_statement", "debugger_statement", "class_declaration", "field_definition", "public_field_definition", "function_declaration"}) do
+for _, t in pairs({"type_alias_declaration", "expression_statement", "variable_declaration", "return_statement", "throw_statement", "break_statement", "continue_statement", "debugger_statement", "class_declaration", "field_definition", "public_field_definition", "function_declaration"}) do
   node_handlers[t] = handle_statement
 end
 M.transform = function(s)

--- a/lua/conjure/client/javascript/transformers.lua
+++ b/lua/conjure/client/javascript/transformers.lua
@@ -130,10 +130,8 @@ local function transform_arrow_fn(arrow_fn, name, code)
   local forbidden = body_contains_forbidden_keyword_3f(body_node, code)
   if forbidden then
     local ln, col = forbidden:start()
-    local par = arrow_fn:parent()
-    local par0 = handle_statement(par:parent(), code)
     handle_transform_error({type = "warn", info = ("Cannot transform arrow function, it contains '" .. forbidden:type() .. "'"), ln = ln, col = col})
-    return par0
+    return nil
   else
     local params = tsc["get-text"](tsc["get-child"](arrow_fn, "parameters"), code)
     local body_text = transform(body_node, code)
@@ -165,7 +163,7 @@ local function _19_(node, code)
   local value_node = (var_decl and (var_decl:type() == "variable_declarator") and tsc["get-child"](var_decl, "value"))
   if (value_node and ("arrow_function" == value_node:type())) then
     local name = tsc["get-text"](tsc["get-child"](var_decl, "name"), code)
-    return transform_arrow_fn(value_node, name, code)
+    return (transform_arrow_fn(value_node, name, code) or handle_statement(node, code))
   else
     return handle_statement(node, code)
   end


### PR DESCRIPTION
Hello! I’ve fixed several crucial bugs affecting multiline string support. Previously, strings like `"Monday.\n Tuesday\n"` were flattened into a single line (e.g., `"Monday. Tuesday."`). Now, newlines are preserved as expected and are no longer transformed.

Regarding the TypeScript client, I fixed a bug where type imports — such as `import type { Result } from "error"` — were not functioning correctly. These imports now work as intended.

Finally, I addressed a major Developer Experience issue. Previously, when a transformation error occurred in an arrow function containing a forbidden keyword (like `this`), the code would throw an exception in the REPL and halt further transformation. This could lead to unexpected behavior. Now, the system instead issues a warning explaining that the function cannot be transformed due to potential `this` context loss, allowing execution to continue safely.