### PR TITLE
Have parse! rely on non-nil returned parser to determine success

### DIFF
--- a/fnl/conjure/tree-sitter.fnl
+++ b/fnl/conjure/tree-sitter.fnl
@@ -21,8 +21,8 @@
     false))
 
 (fn parse! []
-  (let [(ok? parser) (pcall vim.treesitter.get_parser)]
-    (if ok?
+  (let [(_ parser) (pcall vim.treesitter.get_parser)]
+    (if (not= nil parser)
       (parser:parse))))
 
 (fn node->str [node]

--- a/fnl/conjure/tree-sitter.fnl
+++ b/fnl/conjure/tree-sitter.fnl
@@ -21,8 +21,8 @@
     false))
 
 (fn parse! []
-  (let [(_ parser) (pcall vim.treesitter.get_parser)]
-    (if (not= nil parser)
+  (let [(ok? parser) (pcall vim.treesitter.get_parser)]
+    (if (and ok? (not= nil parser))
       (parser:parse))))
 
 (fn node->str [node]

--- a/lua/conjure/tree-sitter.lua
+++ b/lua/conjure/tree-sitter.lua
@@ -18,8 +18,8 @@ local function enabled_3f()
   end
 end
 local function parse_21()
-  local ok_3f, parser = pcall(vim.treesitter.get_parser)
-  if ok_3f then
+  local _, parser = pcall(vim.treesitter.get_parser)
+  if (nil ~= parser) then
     return parser:parse()
   else
     return nil

--- a/lua/conjure/tree-sitter.lua
+++ b/lua/conjure/tree-sitter.lua
@@ -18,8 +18,8 @@ local function enabled_3f()
   end
 end
 local function parse_21()
-  local _, parser = pcall(vim.treesitter.get_parser)
-  if (nil ~= parser) then
+  local ok_3f, parser = pcall(vim.treesitter.get_parser)
+  if (ok_3f and (nil ~= parser)) then
     return parser:parse()
   else
     return nil


### PR DESCRIPTION
I found the underlying `vim.treesitter.get_parser` function in `tree-sitter.parse!` was always returning true in the first return value even in failure.  e.g. 

```
true, nil 
```
with error (which is the [final return value](https://neovim.io/doc/user/treesitter/#vim.treesitter.get_parser()))
 
> Parser could not be created for buffer 3 and language "DiffviewFiles"

When the call is successful I get something like

```
true, table: 0x010165a190
```

with returned error message of `nil`.

I was able to trigger the failure with the `diffview` plugin by editing a lisp file in a git repo, closing neovim and opening it without arguments (i.e. without opening any files), then invoking `:DiffviewOpen`.  I believe in this scenario conjure is invoked because it is associated with one of the buffers, but it is trying to call `parse!` all buffers, one of which does not have a treesitter language registered.

This will have a followup PR for the tree-sitter completions to guard around failed parsing.  I pulled this out separately as we've done general bug fixes like this in their own PRs.