### PR TITLE
Completion parse guards

### DIFF
--- a/fnl/conjure/tree-sitter-completions.fnl
+++ b/fnl/conjure/tree-sitter-completions.fnl
@@ -83,18 +83,18 @@
   ;; To avoid getting an invalid node when calling M.get-completions-at-cursor, ensure
   ;; that the buffer is parsed.
   ;; See the note for `:he treesitter.get_node` and `:he languagetree`.
-  (ts.parse!)
-  (let [buffer         (vim.api.nvim_get_current_buf)
-        cursor-node    (vim.treesitter.get_node)
-        (row _)        (unpack (vim.api.nvim_win_get_cursor 0))
-        scope-captures (query:iter_captures (cursor-node:root) buffer 0 row)
-        scopes         (extract-scopes query scope-captures)
-        captures       (query:iter_captures (cursor-node:root) buffer 0 row)
-        results        []]
+  (if (not= nil (ts.parse!))
+    (let [buffer         (vim.api.nvim_get_current_buf)
+          cursor-node    (vim.treesitter.get_node)
+          (row _)        (unpack (vim.api.nvim_win_get_cursor 0))
+          scope-captures (query:iter_captures (cursor-node:root) buffer 0 row)
+          scopes         (extract-scopes query scope-captures)
+          captures       (query:iter_captures (cursor-node:root) buffer 0 row)
+          results        []]
 
-    (each [id n meta captures]
-      (let [captured-label (. query.captures id)]
-        (if (= :global.define captured-label)
+      (each [id n meta captures]
+        (let [captured-label (. query.captures id)]
+          (if (= :global.define captured-label)
             (table.insert results (get-node-text n buffer meta))
 
             (and (= :local.bind captured-label)
@@ -107,7 +107,8 @@
                  (is-in-scope cursor-node (get-nth-scope-parent 2 n scopes)))
             (table.insert results (get-node-text n buffer meta)))))
 
-    (util.ordered-distinct results)))
+      (util.ordered-distinct results))
+    []))
 
 (fn M.get-completions-at-cursor [ts-lang cmpl-resource]
   "Use tree-sitter query to find completions in scope at cursor

--- a/fnl/conjure/tree-sitter-completions.fnl
+++ b/fnl/conjure/tree-sitter-completions.fnl
@@ -12,8 +12,9 @@
 
 (fn build-completion-query [ts-lang cmpl-resource]
   (let [query-path (string.format symbol-query-path-template cmpl-resource)
-        query-text (res.get-resource-contents query-path) ]
-    (if query-text
+        query-text (res.get-resource-contents query-path) 
+        lang-avail (pcall vim.treesitter.language.inspect ts-lang)]
+    (if (and query-text lang-avail)
       (vim.treesitter.query.parse ts-lang query-text)
       nil)))
 

--- a/lua/conjure/tree-sitter-completions.lua
+++ b/lua/conjure/tree-sitter-completions.lua
@@ -12,7 +12,8 @@ local query_cache = {}
 local function build_completion_query(ts_lang, cmpl_resource)
   local query_path = string.format(symbol_query_path_template, cmpl_resource)
   local query_text = res["get-resource-contents"](query_path)
-  if query_text then
+  local lang_avail = pcall(vim.treesitter.language.inspect, ts_lang)
+  if (query_text and lang_avail) then
     return vim.treesitter.query.parse(ts_lang, query_text)
   else
     return nil

--- a/lua/conjure/tree-sitter-completions.lua
+++ b/lua/conjure/tree-sitter-completions.lua
@@ -99,26 +99,29 @@ local function get_node_text(node, buffer, meta)
   end
 end
 local function get_completions_for_query(query)
-  ts["parse!"]()
-  local buffer = vim.api.nvim_get_current_buf()
-  local cursor_node = vim.treesitter.get_node()
-  local row, _ = unpack(vim.api.nvim_win_get_cursor(0))
-  local scope_captures = query:iter_captures(cursor_node:root(), buffer, 0, row)
-  local scopes = extract_scopes(query, scope_captures)
-  local captures = query:iter_captures(cursor_node:root(), buffer, 0, row)
-  local results = {}
-  for id, n, meta in captures do
-    local captured_label = query.captures[id]
-    if ("global.define" == captured_label) then
-      table.insert(results, get_node_text(n, buffer, meta))
-    elseif (("local.bind" == captured_label) and not cursor_node:equal(n:parent()) and is_in_scope(cursor_node, get_nth_scope_parent(1, n, scopes))) then
-      table.insert(results, get_node_text(n, buffer, meta))
-    elseif (("local.define" == captured_label) and not cursor_node:equal(n:parent()) and is_in_scope(cursor_node, get_nth_scope_parent(2, n, scopes))) then
-      table.insert(results, get_node_text(n, buffer, meta))
-    else
+  if (nil ~= ts["parse!"]()) then
+    local buffer = vim.api.nvim_get_current_buf()
+    local cursor_node = vim.treesitter.get_node()
+    local row, _ = unpack(vim.api.nvim_win_get_cursor(0))
+    local scope_captures = query:iter_captures(cursor_node:root(), buffer, 0, row)
+    local scopes = extract_scopes(query, scope_captures)
+    local captures = query:iter_captures(cursor_node:root(), buffer, 0, row)
+    local results = {}
+    for id, n, meta in captures do
+      local captured_label = query.captures[id]
+      if ("global.define" == captured_label) then
+        table.insert(results, get_node_text(n, buffer, meta))
+      elseif (("local.bind" == captured_label) and not cursor_node:equal(n:parent()) and is_in_scope(cursor_node, get_nth_scope_parent(1, n, scopes))) then
+        table.insert(results, get_node_text(n, buffer, meta))
+      elseif (("local.define" == captured_label) and not cursor_node:equal(n:parent()) and is_in_scope(cursor_node, get_nth_scope_parent(2, n, scopes))) then
+        table.insert(results, get_node_text(n, buffer, meta))
+      else
+      end
     end
+    return util["ordered-distinct"](results)
+  else
+    return {}
   end
-  return util["ordered-distinct"](results)
 end
 M["get-completions-at-cursor"] = function(ts_lang, cmpl_resource)
   local query = get_completion_query(ts_lang, cmpl_resource)
@@ -132,13 +135,13 @@ M["make-prefix-filter"] = function(prefix)
   local sanitized_prefix = string.gsub((prefix or ""), "%%", "%%%%")
   local prefix_pattern = ("^" .. sanitized_prefix)
   local prefix_filter
-  local function _15_(s)
+  local function _16_(s)
     return string.match(s, prefix_pattern)
   end
-  prefix_filter = _15_
-  local function _16_(list)
+  prefix_filter = _16_
+  local function _17_(list)
     return a.filter(prefix_filter, list)
   end
-  return _16_
+  return _17_
 end
 return M


### PR DESCRIPTION
This PR addresses two potential issues in completions which could lead to nvim errors.

1.  A continuation from [PR 772](https://github.com/Olical/conjure/pull/772).  If `parse!` fails, conjure will not attempt to query for completions and return an empty list instead.  Triggering the error is described in the above PR when multiple buffers are opened but not all have tree sitter languages available.

2. If a treesitter language is not installed conjure will not attempt to parse the completion query, a precursor to searching for completions.  I am able to trigger this by running `:TSUninstall <language>` and opening a file that will attempt tree sitter completions before the language is reinstalled.