### PR TITLE
Add python virtual env tip, fix __name__ doc

### DIFF
--- a/doc/conjure-client-python-stdio.txt
+++ b/doc/conjure-client-python-stdio.txt
@@ -19,11 +19,18 @@ We set `__name__` to `__repl__` which means you can alter your program entry
 point to include `__repl__` if you wish to execute your software from the REPL
 as well as the command line.
 >python
- if __name__ == "__main__" or "__repl__":
+ if __name__ in ("__main__", "__repl__"):
 
 Once you have tree sitter installed and configured (remember to run
 `:TSInstall python`!) you should be able to evaluate forms just like you would
 in any other Conjure supported language.
+
+By default, Conjure uses `python3` to create a REPL, which can be best managed
+using Python virtual environments. Look for how to "activate" a virtual
+environment using your Python build tool of choice. For example, running
+`eval $(poetry env activate)` before opening Neovim makes `python3` equivalent
+to `poetry run python3`, enabling Conjure to seamlessly integrate with your
+Poetry project.
 
 Check out `:ConjureSchool` if you're unsure about what evaluation operations
 you can perform.
@@ -64,7 +71,9 @@ All configuration can be set as described in |conjure-configuration|.
                                        *g:conjure#client#python#stdio#command*
 `g:conjure#client#python#stdio#command`
             Command used to start the Python REPL, you can modify this to add
-            arguments or change the command entirely.
+            arguments or change the command entirely. Tip: Start Neovim within
+            a Python virtual environment to make best use of the default
+            command.
             Default: `"python3 -iq"`
 
                                 *g:conjure#client#python#stdio#prompt_pattern*


### PR DESCRIPTION
Coming from Clojure it wasn't obvious to me how to connect Conjure to a Python REPL within an actual project managed by e.g., Poetry. This doc should help people like myself figure it out more quickly.

I noticed the `__name__` snippet was incorrect so I fix that too.