### PR TITLE
Respect config in scheme when treesitter is disabled

### DIFF
--- a/fnl/conjure-spec/tree-sitter-completions_spec.fnl
+++ b/fnl/conjure-spec/tree-sitter-completions_spec.fnl
@@ -1,8 +1,10 @@
 (local {: describe : it : before_each : after_each} (require :plenary.busted))
+(local {: autoload } (require :conjure.nfnl.module))
 (local assert (require :luassert.assert))
 (local res (require :conjure.resources))
 (local ts (require :conjure.tree-sitter))
 (local tsc (require :conjure.tree-sitter-completions))
+(local config (autoload :conjure.config))
 
 (var saved-get-resource-contents nil)
 (var saved-parse! nil)
@@ -37,7 +39,8 @@
         (set saved-parse! ts.parse!)
         (set saved-query-parse vim.treesitter.query.parse)
         (set saved-language-inspect vim.treesitter.language.inspect)
-        (set saved-get-node vim.treesitter.get_node)))
+        (set saved-get-node vim.treesitter.get_node)
+        (config.assoc-in [:extract :tree_sitter :enabled ] true)))
 
     (after_each
       (fn []
@@ -45,7 +48,8 @@
         (tset ts :parse! saved-parse!)
         (tset vim.treesitter.query :parse saved-query-parse)
         (tset vim.treesitter.language :inspect saved-language-inspect)
-        (tset vim.treesitter :get_node saved-get-node)))
+        (tset vim.treesitter :get_node saved-get-node)
+        (config.assoc-in [:extract :tree_sitter :enabled ] true)))
 
     (it "returns no completions when the tree-sitter language is unavailable"
         (fn []
@@ -59,12 +63,31 @@
                             :missing-test-lang
                             :missing-test-resource))))
 
+    (it "does not call tree-sitter api when the tree-sitter is disabled in config"
+        (fn []
+          (var called-treesitter-api false)
+          (tset res :get-resource-contents (fn [_] "(query)"))
+          (tset vim.treesitter.language :inspect
+                (fn [_]  
+                  (set called-treesitter-api true) 
+                  (error "language not found")))
+          (tset ts :parse! 
+                (fn [] 
+                  (set called-treesitter-api true) 
+                  (error "parse should not be called")))
+          (tset vim.treesitter.query :parse
+                (fn [_ _] 
+                  (set called-treesitter-api true) 
+                  (error "query parse should not be called")))
+          (config.assoc-in [:extract :tree_sitter :enabled] false)
+
+          (assert.same [] (tsc.get-completions-at-cursor
+                            :missing-test-lang
+                            :missing-test-resource))
+          (assert.is_false called-treesitter-api)))
+
     (it "returns no completions when parsing the current buffer fails"
         (fn []
-          (tset res :get-resource-contents (fn [_] "(query)"))
-          (tset vim.treesitter.language :inspect (fn [_] {}))
-          (tset vim.treesitter.query :parse (fn [_ _] {}))
-          (tset ts :parse! (fn [] nil))
           (tset vim.treesitter :get_node
                 (fn [] (error "get_node should not be called")))
 

--- a/fnl/conjure-spec/tree-sitter_spec.fnl
+++ b/fnl/conjure-spec/tree-sitter_spec.fnl
@@ -1,7 +1,10 @@
 (local {: describe : it : before_each : after_each } (require :plenary.busted))
+(local {: autoload } (require :conjure.nfnl.module))
 (local ts (require :conjure.tree-sitter))
+(local config (autoload :conjure.config))
 
 (var saved-get-string-parser nil)
+(var saved-get-parser nil)
 
 (describe "conjure.tree-sitter"
   (fn []
@@ -9,10 +12,15 @@
       (fn []
         (before_each
           (fn []
-            (set saved-get-string-parser vim.treesitter.get_string_parser)))
+            (set saved-get-string-parser vim.treesitter.get_string_parser)
+            (set saved-get-parser vim.treesitter.get_parser)
+            (config.assoc-in [:extract :tree_sitter :enabled ] true)
+            (tset vim.treesitter :get_parser (fn [] {}))))
         (after_each
           (fn []
-            (tset vim.treesitter :get_string_parser saved-get-string-parser)))
+            (tset vim.treesitter :get_string_parser saved-get-string-parser)
+            (tset vim.treesitter :get_parser saved-get-parser)
+            (config.assoc-in [:extract :tree_sitter :enabled ] true)))
 
         (it "returns false when root node has error"
             (fn []
@@ -57,4 +65,14 @@
                       (fn [] {:parse (fn [])
                               :trees (fn [] [mock-root-tree])}))
 
-                (assert.is_true (ts.valid-str? :some-lang "(some code)")))))))))
+                (assert.is_true (ts.valid-str? :some-lang "(some code)")))))
+
+        (it "returns true when treesitter is disabled in config"
+            (fn []
+                (config.assoc-in [:extract :tree_sitter :enabled] false)
+                (assert.is_true (ts.valid-str? :some-lang "(some bad code"))))
+
+        (it "returns true when treesitter is not present"
+            (fn []
+              (tset vim.treesitter :get_parser nil)
+              (assert.is_true (ts.valid-str? :some-lang "(some bad code"))))))))

--- a/fnl/conjure/tree-sitter-completions.fnl
+++ b/fnl/conjure/tree-sitter-completions.fnl
@@ -120,10 +120,12 @@
 
   Returns:
   - deduplicated array of strings"
-  (let [query (get-completion-query ts-lang cmpl-resource)]
+  (if (ts.enabled?) 
+    (let [query (get-completion-query ts-lang cmpl-resource)]
     (if query
       (get-completions-for-query query)
-      [])))
+      []))
+    []))
 
 (fn M.make-prefix-filter [prefix]
   "Return function which filters words starting with prefix"

--- a/fnl/conjure/tree-sitter.fnl
+++ b/fnl/conjure/tree-sitter.fnl
@@ -207,9 +207,11 @@
           (root-tree:root))))))
 
 (fn valid-str? [lang code]
-  (let [root-node (get-root-node-for-str lang code)]
-    (and root-node
-         (not (root-node:has_error)))))
+  (if (enabled?)
+    (let [root-node (get-root-node-for-str lang code)]
+      (and root-node
+           (not (root-node:has_error))))
+    true))
 
 {: enabled?
  : parse!

--- a/lua/conjure-spec/tree-sitter-completions_spec.lua
+++ b/lua/conjure-spec/tree-sitter-completions_spec.lua
@@ -4,91 +4,104 @@ local describe = _local_1_.describe
 local it = _local_1_.it
 local before_each = _local_1_.before_each
 local after_each = _local_1_.after_each
+local _local_2_ = require("conjure.nfnl.module")
+local autoload = _local_2_.autoload
 local assert = require("luassert.assert")
 local res = require("conjure.resources")
 local ts = require("conjure.tree-sitter")
 local tsc = require("conjure.tree-sitter-completions")
+local config = autoload("conjure.config")
 local saved_get_resource_contents = nil
 local saved_parse_21 = nil
 local saved_query_parse = nil
 local saved_language_inspect = nil
 local saved_get_node = nil
-local function _2_()
-  local function _3_()
+local function _3_()
+  local function _4_()
     local filter = tsc["make-prefix-filter"]("aa")
     return assert.same({"aaa"}, filter({"aaa", "bbb", "abb"}))
   end
-  it("filters to aaa from aaa bbb abb with prefix aa", _3_)
-  local function _4_()
+  it("filters to aaa from aaa bbb abb with prefix aa", _4_)
+  local function _5_()
     local filter = tsc["make-prefix-filter"]("%")
     return assert.same({"%thing"}, filter({"aaa", "%thing", "b%b"}))
   end
-  it("filters to %thing from aaa %thing b%b with prefix %", _4_)
-  local function _5_()
+  it("filters to %thing from aaa %thing b%b with prefix %", _5_)
+  local function _6_()
     local filter = tsc["make-prefix-filter"](nil)
     return assert.same({"aaa", "word", "2342"}, filter({"aaa", "word", "2342"}))
   end
-  return it("filters nothing from aaa word 2342 with prefix nil", _5_)
+  return it("filters nothing from aaa word 2342 with prefix nil", _6_)
 end
-describe("make-prefix-filter", _2_)
-local function _6_()
-  local function _7_()
+describe("make-prefix-filter", _3_)
+local function _7_()
+  local function _8_()
     saved_get_resource_contents = res["get-resource-contents"]
     saved_parse_21 = ts["parse!"]
     saved_query_parse = vim.treesitter.query.parse
     saved_language_inspect = vim.treesitter.language.inspect
     saved_get_node = vim.treesitter.get_node
-    return nil
+    return config["assoc-in"]({"extract", "tree_sitter", "enabled"}, true)
   end
-  before_each(_7_)
-  local function _8_()
+  before_each(_8_)
+  local function _9_()
     res["get-resource-contents"] = saved_get_resource_contents
     ts["parse!"] = saved_parse_21
     vim.treesitter.query["parse"] = saved_query_parse
     vim.treesitter.language["inspect"] = saved_language_inspect
     vim.treesitter["get_node"] = saved_get_node
-    return nil
+    return config["assoc-in"]({"extract", "tree_sitter", "enabled"}, true)
   end
-  after_each(_8_)
-  local function _9_()
-    local function _10_(_)
+  after_each(_9_)
+  local function _10_()
+    local function _11_(_)
       return "(query)"
     end
-    res["get-resource-contents"] = _10_
-    local function _11_(_)
+    res["get-resource-contents"] = _11_
+    local function _12_(_)
       return error("language not found")
     end
-    vim.treesitter.language["inspect"] = _11_
-    local function _12_(_, _0)
+    vim.treesitter.language["inspect"] = _12_
+    local function _13_(_, _0)
       return error("query parse should not be called")
     end
-    vim.treesitter.query["parse"] = _12_
+    vim.treesitter.query["parse"] = _13_
     return assert.same({}, tsc["get-completions-at-cursor"]("missing-test-lang", "missing-test-resource"))
   end
-  it("returns no completions when the tree-sitter language is unavailable", _9_)
-  local function _13_()
-    local function _14_(_)
+  it("returns no completions when the tree-sitter language is unavailable", _10_)
+  local function _14_()
+    local called_treesitter_api = false
+    local function _15_(_)
       return "(query)"
     end
-    res["get-resource-contents"] = _14_
-    local function _15_(_)
-      return {}
+    res["get-resource-contents"] = _15_
+    local function _16_(_)
+      called_treesitter_api = true
+      return error("language not found")
     end
-    vim.treesitter.language["inspect"] = _15_
-    local function _16_(_, _0)
-      return {}
-    end
-    vim.treesitter.query["parse"] = _16_
+    vim.treesitter.language["inspect"] = _16_
     local function _17_()
-      return nil
+      called_treesitter_api = true
+      return error("parse should not be called")
     end
     ts["parse!"] = _17_
-    local function _18_()
+    local function _18_(_, _0)
+      called_treesitter_api = true
+      return error("query parse should not be called")
+    end
+    vim.treesitter.query["parse"] = _18_
+    config["assoc-in"]({"extract", "tree_sitter", "enabled"}, false)
+    assert.same({}, tsc["get-completions-at-cursor"]("missing-test-lang", "missing-test-resource"))
+    return assert.is_false(called_treesitter_api)
+  end
+  it("does not call tree-sitter api when the tree-sitter is disabled in config", _14_)
+  local function _19_()
+    local function _20_()
       return error("get_node should not be called")
     end
-    vim.treesitter["get_node"] = _18_
+    vim.treesitter["get_node"] = _20_
     return assert.same({}, tsc["get-completions-at-cursor"]("parse-fail-test-lang", "parse-fail-test-resource"))
   end
-  return it("returns no completions when parsing the current buffer fails", _13_)
+  return it("returns no completions when parsing the current buffer fails", _19_)
 end
-return describe("get-completions-at-cursor", _6_)
+return describe("get-completions-at-cursor", _7_)

--- a/lua/conjure-spec/tree-sitter_spec.lua
+++ b/lua/conjure-spec/tree-sitter_spec.lua
@@ -4,111 +4,132 @@ local describe = _local_1_.describe
 local it = _local_1_.it
 local before_each = _local_1_.before_each
 local after_each = _local_1_.after_each
+local _local_2_ = require("conjure.nfnl.module")
+local autoload = _local_2_.autoload
 local ts = require("conjure.tree-sitter")
+local config = autoload("conjure.config")
 local saved_get_string_parser = nil
-local function _2_()
-  local function _3_()
-    local function _4_()
-      saved_get_string_parser = vim.treesitter.get_string_parser
-      return nil
-    end
-    before_each(_4_)
+local saved_get_parser = nil
+local function _3_()
+  local function _4_()
     local function _5_()
-      vim.treesitter["get_string_parser"] = saved_get_string_parser
+      saved_get_string_parser = vim.treesitter.get_string_parser
+      saved_get_parser = vim.treesitter.get_parser
+      config["assoc-in"]({"extract", "tree_sitter", "enabled"}, true)
+      local function _6_()
+        return {}
+      end
+      vim.treesitter["get_parser"] = _6_
       return nil
     end
-    after_each(_5_)
-    local function _6_()
+    before_each(_5_)
+    local function _7_()
+      vim.treesitter["get_string_parser"] = saved_get_string_parser
+      vim.treesitter["get_parser"] = saved_get_parser
+      return config["assoc-in"]({"extract", "tree_sitter", "enabled"}, true)
+    end
+    after_each(_7_)
+    local function _8_()
       local mock_root_node
-      local function _7_()
+      local function _9_()
         return true
       end
-      mock_root_node = {has_error = _7_}
+      mock_root_node = {has_error = _9_}
       local mock_root_tree
-      local function _8_()
+      local function _10_()
         return mock_root_node
       end
-      mock_root_tree = {root = _8_}
-      local function _9_()
-        local function _10_()
+      mock_root_tree = {root = _10_}
+      local function _11_()
+        local function _12_()
         end
-        local function _11_()
+        local function _13_()
           return {mock_root_tree}
         end
-        return {parse = _10_, trees = _11_}
+        return {parse = _12_, trees = _13_}
       end
-      vim.treesitter["get_string_parser"] = _9_
+      vim.treesitter["get_string_parser"] = _11_
       return assert.is_false(ts["valid-str?"]("some-lang", "(some bad code"))
     end
-    it("returns false when root node has error", _6_)
-    local function _12_()
-      local function _13_()
-        local function _14_()
+    it("returns false when root node has error", _8_)
+    local function _14_()
+      local function _15_()
+        local function _16_()
         end
-        local function _15_()
+        local function _17_()
           return nil
         end
-        return {parse = _14_, trees = _15_}
+        return {parse = _16_, trees = _17_}
       end
-      vim.treesitter["get_string_parser"] = _13_
+      vim.treesitter["get_string_parser"] = _15_
       return assert.is_falsy(ts["valid-str?"]("some-lang", "code"))
     end
-    it("returns falsy when nil parse trees is returned", _12_)
-    local function _16_()
-      local function _17_()
-        local function _18_()
+    it("returns falsy when nil parse trees is returned", _14_)
+    local function _18_()
+      local function _19_()
+        local function _20_()
         end
-        local function _19_()
+        local function _21_()
           return {}
         end
-        return {parse = _18_, trees = _19_}
+        return {parse = _20_, trees = _21_}
       end
-      vim.treesitter["get_string_parser"] = _17_
+      vim.treesitter["get_string_parser"] = _19_
       return assert.is_falsy(ts["valid-str?"]("some-lang", "code"))
     end
-    it("returns falsy when empty parse trees array is returned", _16_)
-    local function _20_()
+    it("returns falsy when empty parse trees array is returned", _18_)
+    local function _22_()
       local mock_root_tree
-      local function _21_()
+      local function _23_()
         return nil
       end
-      mock_root_tree = {root = _21_}
-      local function _22_()
-        local function _23_()
+      mock_root_tree = {root = _23_}
+      local function _24_()
+        local function _25_()
         end
-        local function _24_()
+        local function _26_()
           return {mock_root_tree}
         end
-        return {parse = _23_, trees = _24_}
+        return {parse = _25_, trees = _26_}
       end
-      vim.treesitter["get_string_parser"] = _22_
+      vim.treesitter["get_string_parser"] = _24_
       return assert.is_falsy(ts["valid-str?"]("some-lang", "code"))
     end
-    it("returns falsy when returned root node nil", _20_)
-    local function _25_()
+    it("returns falsy when returned root node nil", _22_)
+    local function _27_()
       local mock_root_node
-      local function _26_()
+      local function _28_()
         return false
       end
-      mock_root_node = {has_error = _26_}
+      mock_root_node = {has_error = _28_}
       local mock_root_tree
-      local function _27_()
+      local function _29_()
         return mock_root_node
       end
-      mock_root_tree = {root = _27_}
-      local function _28_()
-        local function _29_()
+      mock_root_tree = {root = _29_}
+      local function _30_()
+        local function _31_()
         end
-        local function _30_()
+        local function _32_()
           return {mock_root_tree}
         end
-        return {parse = _29_, trees = _30_}
+        return {parse = _31_, trees = _32_}
       end
-      vim.treesitter["get_string_parser"] = _28_
+      vim.treesitter["get_string_parser"] = _30_
       return assert.is_true(ts["valid-str?"]("some-lang", "(some code)"))
     end
-    return it("returns true when root node does not have errors", _25_)
+    it("returns true when root node does not have errors", _27_)
+    local function _33_()
+      config["assoc-in"]({"extract", "tree_sitter", "enabled"}, false)
+      return assert.is_true(ts["valid-str?"]("some-lang", "(some bad code"))
+    end
+    it("returns true when treesitter is disabled in config", _33_)
+    local function _34_()
+      vim.treesitter["get_parser"] = nil
+      return assert.is_true(ts["valid-str?"]("some-lang", "(some bad code"))
+    end
+    return it("returns true when treesitter is not present", _34_)
   end
-  return describe("valid-str?", _3_)
+  return describe("valid-str?", _4_)
 end
-return describe("conjure.tree-sitter", _2_)
+return describe("conjure.tree-sitter", _3_)

--- a/lua/conjure/tree-sitter-completions.lua
+++ b/lua/conjure/tree-sitter-completions.lua
@@ -125,9 +125,13 @@ local function get_completions_for_query(query)
   end
 end
 M["get-completions-at-cursor"] = function(ts_lang, cmpl_resource)
-  local query = get_completion_query(ts_lang, cmpl_resource)
-  if query then
-    return get_completions_for_query(query)
+  if ts["enabled?"]() then
+    local query = get_completion_query(ts_lang, cmpl_resource)
+    if query then
+      return get_completions_for_query(query)
+    else
+      return {}
+    end
   else
     return {}
   end
@@ -136,13 +140,13 @@ M["make-prefix-filter"] = function(prefix)
   local sanitized_prefix = string.gsub((prefix or ""), "%%", "%%%%")
   local prefix_pattern = ("^" .. sanitized_prefix)
   local prefix_filter
-  local function _16_(s)
+  local function _17_(s)
     return string.match(s, prefix_pattern)
   end
-  prefix_filter = _16_
-  local function _17_(list)
+  prefix_filter = _17_
+  local function _18_(list)
     return a.filter(prefix_filter, list)
   end
-  return _17_
+  return _18_
 end
 return M

--- a/lua/conjure/tree-sitter.lua
+++ b/lua/conjure/tree-sitter.lua
@@ -198,7 +198,11 @@ local function get_root_node_for_str(lang, code)
   end
 end
 local function valid_str_3f(lang, code)
-  local root_node = get_root_node_for_str(lang, code)
-  return (root_node and not root_node:has_error())
+  if enabled_3f() then
+    local root_node = get_root_node_for_str(lang, code)
+    return (root_node and not root_node:has_error())
+  else
+    return true
+  end
 end
 return {["enabled?"] = enabled_3f, ["parse!"] = parse_21, ["node->str"] = node__3estr, ["lisp-comment-node?"] = lisp_comment_node_3f, parent = parent, ["document?"] = document_3f, range = range, ["node->table"] = node__3etable, ["get-root"] = get_root, ["leaf?"] = leaf_3f, ["sym?"] = sym_3f, ["get-leaf"] = get_leaf, ["node-surrounded-by-form-pair-chars?"] = node_surrounded_by_form_pair_chars_3f, ["node-prefixed-by-chars?"] = node_prefixed_by_chars_3f, ["get-form"] = get_form, ["add-language"] = add_language, ["valid-str?"] = valid_str_3f}


### PR DESCRIPTION
Currently the scheme and guile clients will call tree-sitter facilities when validating a string to be evaluated by the repl even if `#extract#tree_sitter#enabled` is false in the config.  Furthermore the treesitter completions will also call some facilities if it is disabled (this has been harmless due to failure checks) but should also respect the config.

Added a `ts.enabled?` guard around `get-completions-at-cursor` with tests

Added a `ts.enabled?` check around `valid-str?` which returns true of tree-sitter is disabled with tests