### PR TITLE
Get def_word working with Fennel functions declared via λ/lambda

### DIFF
--- a/res/queries/fennel/ext-def.scm
+++ b/res/queries/fennel/ext-def.scm
@@ -1,8 +1,13 @@
 (local_form
  (binding_pair
-   lhs: (symbol_binding) @local.def)) 
+   lhs: (symbol_binding) @local.def))
 (fn_form
   name: (symbol) @fn.def)
 (fn_form
+  name: (multi_symbol
+    member: (symbol_fragment) @fn.def))
+(lambda_form
+  name: (symbol) @fn.def)
+(lambda_form
   name: (multi_symbol
     member: (symbol_fragment) @fn.def))

--- a/res/queries/fennel/local-def.scm
+++ b/res/queries/fennel/local-def.scm
@@ -1,5 +1,7 @@
 (local_form
  (binding_pair
-   lhs: (symbol_binding) @local.def)) 
+   lhs: (symbol_binding) @local.def))
 (fn_form
+  name: [(symbol) (multi_symbol)] @local.fn.def)
+(lambda_form
   name: [(symbol) (multi_symbol)] @local.fn.def)


### PR DESCRIPTION
Fennel functions declared with `λ`/`lambda` have TS nodes of `lambda_form` rather than `fn_form`.