### PR TITLE
Add doc-str support to SQL client

### DIFF
--- a/doc/conjure-client-sql-stdio.txt
+++ b/doc/conjure-client-sql-stdio.txt
@@ -19,11 +19,10 @@ Conjure starts a SQL REPL within Neovim when you first open a SQL file unless
 you set `conjure#client_on_load` to `v:false`.
 
 This client was initially developed using PostgreSQL's `psql` command line
-client. Thus, the default configuration values for `command` and `prompt
-`pattern` are set for `psql`. The `command` string is set to use a connection
-URL to a `postgres` database with a `postgres` user and password of
-`postgres`. The database is served by a local PostgreSQL server listening on
-the default port.
+client. Thus, the default configuration values are geared towards `psql`. The
+`command` string is set to use a connection URL to a `postgres` database with
+a `postgres` user and password of `postgres`. The database is served by
+a local PostgreSQL server listening on the default port.
 
 Also, if you set up a `~/.pgpass` password file, like so:
 
@@ -42,7 +41,6 @@ or
 
 Please note that connecting to databases can be a security risk so consult the
 appropriate people for your particular situation and environment.
-  
 
 You can use another SQL database with its command line client so check the
 |conjure-client-sql-stdio-configuration and the documentation for that command
@@ -120,6 +118,21 @@ All configuration can be set as described in |conjure-configuration|.
             duckdb. When Conjure spots one of these it will avoid appending a
             semi-colon which is required to execute true statements.
             Default: `"^[.\\]%w"`
+
+                           *g:conjure#client#sql#stdio#doc_table*
+`g:conjure#client#sql#stdio#doc_table`
+            REPL command issued to show docs for a table.
+            Default: `"\\d"`
+
+                           *g:conjure#client#sql#stdio#doc_function*
+`g:conjure#client#sql#stdio#doc_function`
+            REPL command issued to show docs for a function.
+            Default: `"\\df+"`
+
+                           *g:conjure#client#sql#stdio#doc_statement*
+`g:conjure#client#sql#stdio#doc_statement`
+            REPL command issued to show docs for a statement.
+            Default: `"\\h"`
 
 ==============================================================================
 TROUBLESHOOTING                         *conjure-client-sql-stdio-trouble*

--- a/fnl/conjure/client/sql/stdio.fnl
+++ b/fnl/conjure/client/sql/stdio.fnl
@@ -7,6 +7,7 @@
 (local config (autoload :conjure.config))
 (local mapping (autoload :conjure.mapping))
 (local ts (autoload :conjure.tree-sitter))
+(local ts-sql (autoload :conjure.client.sql.tree-sitter))
 
 (local M (define :conjure.client.sql.stdio))
 
@@ -25,7 +26,10 @@
     {:stdio
      {:command "psql postgres://postgres:postgres@localhost/postgres"
       :meta_prefix_pattern "^[.\\]%w"
-      :prompt_pattern "=> "}}}})
+      :prompt_pattern "=> "
+      :doc_table "\\d"
+      :doc_function "\\df+"
+      :doc_statement "\\h"}}}})
 
 (when (config.get-in [:mapping :enable_defaults])
   (config.merge
@@ -37,7 +41,7 @@
                   :interrupt "ei"}}}}}))
 
 (local cfg (config.get-in-fn [:client :sql :stdio]))
-(local state (client.new-state #(do {:repl nil})))
+(local state (client.new-state #{:repl nil}))
 
 (set M.buf-suffix ".sql")
 (set M.comment-prefix "-- ")
@@ -124,6 +128,16 @@
             (a.run! display-result msgs)))
         {:batch? false}))))
 ;;;;-------- End from client/fennel/stdio.fnl ------------------
+
+(fn M.doc-str [opts]
+  (let [what (if (ts.enabled?)
+                 (ts-sql.describe-at-cursor)
+                 {:command (cfg [:doc_table]) :target opts.code})]
+    (case what
+      (where {: command : target} (not (a.empty? target)))
+      (M.eval-str (a.assoc opts :code (.. command " " target)))
+      _
+      (log.append [(.. M.comment-prefix "Nothing to describe under the cursor")]))))
 
 (fn M.eval-file [opts]
   (M.eval-str (a.assoc opts :code (a.slurp opts.file-path))))

--- a/fnl/conjure/client/sql/tree-sitter.fnl
+++ b/fnl/conjure/client/sql/tree-sitter.fnl
@@ -5,7 +5,7 @@
 
 (local cfg (config.get-in-fn [:client :sql :stdio]))
 
-(local M (define :conjure.client.sql.stdio.doc-str))
+(local M (define :conjure.client.sql.tree-sitter))
 
 (set M.statement-types {:statement true})
 (set M.command-wrapper-types {:statement true :transaction true})

--- a/fnl/conjure/client/sql/tree-sitter.fnl
+++ b/fnl/conjure/client/sql/tree-sitter.fnl
@@ -1,0 +1,98 @@
+(local {: autoload : define} (require :conjure.nfnl.module))
+
+(local config (autoload :conjure.config))
+(local ts (autoload :conjure.tree-sitter))
+
+(local cfg (config.get-in-fn [:client :sql :stdio]))
+
+(local M (define :conjure.client.sql.stdio.doc-str))
+
+(set M.statement-types {:statement true})
+(set M.command-wrapper-types {:statement true :transaction true})
+
+(fn M.ancestor-of-type [?node types]
+  (if (or (= nil ?node) (?. types (?node:type)))
+      ?node
+      (tail! (M.ancestor-of-type (?node:parent) types))))
+
+(fn M.relations [node]
+  (let [rels []]
+    (fn go [node]
+      (each [child (node:iter_children)]
+        (when (= :relation (child:type))
+          (table.insert rels child))
+        (go child)))
+    (go node)
+    rels))
+
+(fn M.relation-parts [relation]
+  (let [parts {}]
+    (each [child (relation:iter_children)]
+      (case (child:type)
+        :object_reference (set parts.ref child)
+        :identifier (set parts.alias child)))
+    parts))
+
+(fn M.alias->object-reference [?statement word]
+  (when ?statement
+    (accumulate [found nil _ relation (ipairs (M.relations ?statement)) &until found]
+      (case (M.relation-parts relation)
+        (where {: ref : alias} (= word (ts.node->str alias)))
+        (ts.node->str ref)))))
+
+(fn M.node-type [?node]
+  (when ?node
+    (?node:type)))
+
+(fn M.child-of-type [node type]
+  (accumulate [found nil child (node:iter_children) &until found]
+    (when (= type (child:type))
+      child)))
+
+(fn M.reference-node [leaf]
+  (let [parent (leaf:parent)]
+    (case (M.node-type parent)
+      :object_reference parent
+      :field (M.child-of-type parent :object_reference)
+      _ leaf)))
+
+(local function-parents {:create_function true
+                         :drop_function true
+                         :invocation true})
+
+(fn M.function-reference? [node]
+  (?. function-parents (M.node-type (node:parent))))
+
+(fn M.relation-name [leaf name]
+  (case name
+    (where dotted (dotted:find "%.")) dotted
+    bare (or (M.alias->object-reference (M.ancestor-of-type leaf M.statement-types) bare) bare)))
+
+(fn M.command-node [leaf]
+  (case (M.ancestor-of-type leaf M.command-wrapper-types)
+    wrapper (if (wrapper:equal (leaf:parent))
+                leaf
+                (wrapper:named_child 0))))
+
+(fn M.doc-topic [node]
+  (pick-values 1
+    (-> (node:type)
+        (string.gsub "^keyword_" "")
+        (string.gsub "_statement$" "")
+        (string.gsub "_" " "))))
+
+(fn M.describe-at-cursor []
+  (case (ts.get-leaf)
+    (where leaf (vim.startswith (leaf:type) :keyword_))
+    (case (M.command-node leaf)
+      node {:command (cfg [:doc_statement]) :target (M.doc-topic node)})
+
+    (where leaf (= :identifier (leaf:type)))
+    (case (M.reference-node leaf)
+      node (let [name (ts.node->str node)]
+             (if (M.function-reference? node)
+                 {:command (cfg [:doc_function]) :target name}
+                 {:command (cfg [:doc_table])
+                  :target (M.relation-name leaf name)})))))
+
+M

--- a/lua/conjure/client/sql/stdio.lua
+++ b/lua/conjure/client/sql/stdio.lua
@@ -10,18 +10,19 @@ local stdio = autoload("conjure.remote.stdio-rt")
 local config = autoload("conjure.config")
 local mapping = autoload("conjure.mapping")
 local ts = autoload("conjure.tree-sitter")
+local ts_sql = autoload("conjure.client.sql.tree-sitter")
 local M = define("conjure.client.sql.stdio")
-config.merge({client = {sql = {stdio = {command = "psql postgres://postgres:postgres@localhost/postgres", meta_prefix_pattern = "^[.\\]%w", prompt_pattern = "=> "}}}})
+config.merge({client = {sql = {stdio = {command = "psql postgres://postgres:postgres@localhost/postgres", meta_prefix_pattern = "^[.\\]%w", prompt_pattern = "=> ", doc_table = "\\d", doc_function = "\\df+", doc_statement = "\\h"}}}})
 if config["get-in"]({"mapping", "enable_defaults"}) then
   config.merge({client = {sql = {stdio = {mapping = {start = "cs", stop = "cS", interrupt = "ei"}}}}})
 else
 end
 local cfg = config["get-in-fn"]({"client", "sql", "stdio"})
 local state
-local function _3_()
+local function hashfn_3_()
   return {repl = nil}
 end
-state = client["new-state"](_3_)
+state = client["new-state"](hashfn_3_)
 M["buf-suffix"] = ".sql"
 M["comment-prefix"] = "-- "
 M["get-form-modifier"] = function(node)
@@ -53,10 +54,10 @@ local function format_message(msg)
   return str.split((msg.out or msg.err), "\n")
 end
 local function remove_blank_lines(msg)
-  local function _7_(_241)
+  local function hashfn_7_(_241)
     return not ("" == _241)
   end
-  return a.filter(_7_, format_message(msg))
+  return a.filter(hashfn_7_, format_message(msg))
 end
 local function display_result(msg)
   return log.append(remove_blank_lines(msg))
@@ -81,8 +82,8 @@ M["prep-code"] = function(opts)
 end
 M["eval-str"] = function(opts)
   log.dbg("eval-str: opts >> ", a["pr-str"](opts), "<<")
-  local function _10_(repl)
-    local function _11_(msgs)
+  local function fn_10_(repl)
+    local function fn_11_(msgs)
       local msgs0 = M["->list"](msgs)
       if opts["on-result"] then
         opts["on-result"](str.join("\n", remove_blank_lines(a.last(msgs0))))
@@ -90,19 +91,41 @@ M["eval-str"] = function(opts)
       end
       return a["run!"](display_result, msgs0)
     end
-    return repl.send(M["prep-code"](opts), _11_, {["batch?"] = false})
+    return repl.send(M["prep-code"](opts), fn_11_, {["batch?"] = false})
   end
-  return with_repl_or_warn(_10_)
+  return with_repl_or_warn(fn_10_)
+end
+M["doc-str"] = function(opts)
+  local what
+  if ts["enabled?"]() then
+    what = ts_sql["describe-at-cursor"]()
+  else
+    what = {command = cfg({"doc_table"}), target = opts.code}
+  end
+  local and_14_ = ((_G.type(what) == "table") and (nil ~= what.command) and (nil ~= what.target))
+  if and_14_ then
+    local command = what.command
+    local target = what.target
+    and_14_ = not a["empty?"](target)
+  end
+  if and_14_ then
+    local command = what.command
+    local target = what.target
+    return M["eval-str"](a.assoc(opts, "code", (command .. " " .. target)))
+  else
+    local _ = what
+    return log.append({(M["comment-prefix"] .. "Nothing to describe under the cursor")})
+  end
 end
 M["eval-file"] = function(opts)
   return M["eval-str"](a.assoc(opts, "code", a.slurp(opts["file-path"])))
 end
 M.interrupt = function()
-  local function _13_(repl)
+  local function fn_17_(repl)
     log.append({(M["comment-prefix"] .. " Sending interrupt signal.")}, {["break?"] = true})
     return repl["send-signal"]("sigint")
   end
-  return with_repl_or_warn(_13_)
+  return with_repl_or_warn(fn_17_)
 end
 local function display_repl_status(status)
   local repl = state("repl")
@@ -127,21 +150,21 @@ M.start = function()
   if state("repl") then
     return log.append({(M["comment-prefix"] .. "Can't start, REPL is already running."), (M["comment-prefix"] .. "Stop the REPL with " .. config["get-in"]({"mapping", "prefix"}) .. cfg({"mapping", "stop"}))}, {["break?"] = true})
   else
-    local function _16_()
+    local function fn_20_()
       return display_repl_status("started")
     end
-    local function _17_(err)
+    local function fn_21_(err)
       return display_repl_status(err)
     end
-    local function _18_(code, signal)
+    local function fn_22_(code, signal)
       log.dbg("process exited with code ", a["pr-str"](code))
       log.dbg("process exited with signal ", a["pr-str"](signal))
       return M.stop()
     end
-    local function _19_(msg)
+    local function fn_23_(msg)
       return display_result(msg)
     end
-    return a.assoc(state(), "repl", stdio.start({["prompt-pattern"] = cfg({"prompt_pattern"}), cmd = cfg({"command"}), ["on-success"] = _16_, ["on-error"] = _17_, ["on-exit"] = _18_, ["on-stray-output"] = _19_}))
+    return a.assoc(state(), "repl", stdio.start({["prompt-pattern"] = cfg({"prompt_pattern"}), cmd = cfg({"command"}), ["on-success"] = fn_20_, ["on-error"] = fn_21_, ["on-exit"] = fn_22_, ["on-stray-output"] = fn_23_}))
   end
 end
 M["on-load"] = function()
@@ -155,17 +178,17 @@ M["on-exit"] = function()
   return M.stop()
 end
 M["on-filetype"] = function()
-  local function _22_()
+  local function hashfn_26_()
     return M.start()
   end
-  mapping.buf("SqlStart", cfg({"mapping", "start"}), _22_, {desc = "Start the REPL"})
-  local function _23_()
+  mapping.buf("SqlStart", cfg({"mapping", "start"}), hashfn_26_, {desc = "Start the REPL"})
+  local function hashfn_27_()
     return M.stop()
   end
-  mapping.buf("SqlStop", cfg({"mapping", "stop"}), _23_, {desc = "Stop the REPL"})
-  local function _24_()
+  mapping.buf("SqlStop", cfg({"mapping", "stop"}), hashfn_27_, {desc = "Stop the REPL"})
+  local function hashfn_28_()
     return M.interrupt()
   end
-  return mapping.buf("SqlInterrupt", cfg({"mapping", "interrupt"}), _24_, {desc = "Interrupt the current REPL"})
+  return mapping.buf("SqlInterrupt", cfg({"mapping", "interrupt"}), hashfn_28_, {desc = "Interrupt the current REPL"})
 end
 return M

--- a/lua/conjure/client/sql/tree-sitter.lua
+++ b/lua/conjure/client/sql/tree-sitter.lua
@@ -1,0 +1,193 @@
+-- [nfnl] fnl/conjure/client/sql/tree-sitter.fnl
+local _local_1_ = require("conjure.nfnl.module")
+local autoload = _local_1_.autoload
+local define = _local_1_.define
+local config = autoload("conjure.config")
+local ts = autoload("conjure.tree-sitter")
+local cfg = config["get-in-fn"]({"client", "sql", "stdio"})
+local M = define("conjure.client.sql.stdio.doc-str")
+M["statement-types"] = {statement = true}
+M["command-wrapper-types"] = {statement = true, transaction = true}
+M["ancestor-of-type"] = function(_3fnode, types)
+  local or_2_ = (nil == _3fnode)
+  if not or_2_ then
+    local t_3_ = types
+    if (nil ~= t_3_) then
+      t_3_ = t_3_[_3fnode:type()]
+    else
+    end
+    or_2_ = t_3_
+  end
+  if or_2_ then
+    return _3fnode
+  else
+    return M["ancestor-of-type"](_3fnode:parent(), types)
+  end
+end
+M.relations = function(node)
+  local rels = {}
+  local function go(node0)
+    for child in node0:iter_children() do
+      if ("relation" == child:type()) then
+        table.insert(rels, child)
+      else
+      end
+      go(child)
+    end
+    return nil
+  end
+  go(node)
+  return rels
+end
+M["relation-parts"] = function(relation)
+  local parts = {}
+  for child in relation:iter_children() do
+    local case_7_ = child:type()
+    if (case_7_ == "object_reference") then
+      parts.ref = child
+    elseif (case_7_ == "identifier") then
+      parts.alias = child
+    else
+    end
+  end
+  return parts
+end
+M["alias->object-reference"] = function(_3fstatement, word)
+  if _3fstatement then
+    local found = nil
+    for _, relation in ipairs(M.relations(_3fstatement)) do
+      if found then break end
+      local case_9_ = M["relation-parts"](relation)
+      local and_10_ = ((_G.type(case_9_) == "table") and (nil ~= case_9_.ref) and (nil ~= case_9_.alias))
+      if and_10_ then
+        local ref = case_9_.ref
+        local alias = case_9_.alias
+        and_10_ = (word == ts["node->str"](alias))
+      end
+      if and_10_ then
+        local ref = case_9_.ref
+        local alias = case_9_.alias
+        found = ts["node->str"](ref)
+      else
+        found = nil
+      end
+    end
+    return found
+  else
+    return nil
+  end
+end
+M["node-type"] = function(_3fnode)
+  if _3fnode then
+    return _3fnode:type()
+  else
+    return nil
+  end
+end
+M["child-of-type"] = function(node, type)
+  local found = nil
+  for child in node:iter_children() do
+    if found then break end
+    if (type == child:type()) then
+      found = child
+    else
+      found = nil
+    end
+  end
+  return found
+end
+M["reference-node"] = function(leaf)
+  local parent = leaf:parent()
+  local case_16_ = M["node-type"](parent)
+  if (case_16_ == "object_reference") then
+    return parent
+  elseif (case_16_ == "field") then
+    return M["child-of-type"](parent, "object_reference")
+  else
+    local _ = case_16_
+    return leaf
+  end
+end
+local function_parents = {create_function = true, drop_function = true, invocation = true}
+M["function-reference?"] = function(node)
+  local t_18_ = function_parents
+  if (nil ~= t_18_) then
+    t_18_ = t_18_[M["node-type"](node:parent())]
+  else
+  end
+  return t_18_
+end
+M["relation-name"] = function(leaf, name)
+  local and_20_ = (nil ~= name)
+  if and_20_ then
+    local dotted = name
+    and_20_ = dotted:find("%.")
+  end
+  if and_20_ then
+    local dotted = name
+    return dotted
+  elseif (nil ~= name) then
+    local bare = name
+    return (M["alias->object-reference"](M["ancestor-of-type"](leaf, M["statement-types"]), bare) or bare)
+  else
+    return nil
+  end
+end
+M["command-node"] = function(leaf)
+  local case_23_ = M["ancestor-of-type"](leaf, M["command-wrapper-types"])
+  if (nil ~= case_23_) then
+    local wrapper = case_23_
+    if wrapper:equal(leaf:parent()) then
+      return leaf
+    else
+      return wrapper:named_child(0)
+    end
+  else
+    return nil
+  end
+end
+M["doc-topic"] = function(node)
+  return (string.gsub(string.gsub(string.gsub(node:type(), "^keyword_", ""), "_statement$", ""), "_", " "))
+end
+M["describe-at-cursor"] = function()
+  local case_26_ = ts["get-leaf"]()
+  local and_27_ = (nil ~= case_26_)
+  if and_27_ then
+    local leaf = case_26_
+    and_27_ = vim.startswith(leaf:type(), "keyword_")
+  end
+  if and_27_ then
+    local leaf = case_26_
+    local case_29_ = M["command-node"](leaf)
+    if (nil ~= case_29_) then
+      local node = case_29_
+      return {command = cfg({"doc_statement"}), target = M["doc-topic"](node)}
+    else
+      return nil
+    end
+  else
+    local and_31_ = (nil ~= case_26_)
+    if and_31_ then
+      local leaf = case_26_
+      and_31_ = ("identifier" == leaf:type())
+    end
+    if and_31_ then
+      local leaf = case_26_
+      local case_33_ = M["reference-node"](leaf)
+      if (nil ~= case_33_) then
+        local node = case_33_
+        local name = ts["node->str"](node)
+        if M["function-reference?"](node) then
+          return {command = cfg({"doc_function"}), target = name}
+        else
+          return {command = cfg({"doc_table"}), target = M["relation-name"](leaf, name)}
+        end
+      else
+        return nil
+      end
+    else
+      return nil
+    end
+  end
+end
+return M

--- a/lua/conjure/client/sql/tree-sitter.lua
+++ b/lua/conjure/client/sql/tree-sitter.lua
@@ -5,7 +5,7 @@ local define = _local_1_.define
 local config = autoload("conjure.config")
 local ts = autoload("conjure.tree-sitter")
 local cfg = config["get-in-fn"]({"client", "sql", "stdio"})
-local M = define("conjure.client.sql.stdio.doc-str")
+local M = define("conjure.client.sql.tree-sitter")
 M["statement-types"] = {statement = true}
 M["command-wrapper-types"] = {statement = true, transaction = true}
 M["ancestor-of-type"] = function(_3fnode, types)


### PR DESCRIPTION
Adds doc-str support for the SQL client. It digs around in treesitter to know which help command to send based on what's under the cursor. The default help command prefixes (`\d` for tables, `df+` for functions, and `\h` for statements) are tailored for `psql`. Hopefully the attached demo video is legible! I needed to compress it heavily to fit under GitHub's 10MB limit:

https://github.com/user-attachments/assets/2634c582-ae4c-47cb-97d3-0b70b9afce6c